### PR TITLE
Various fixes and enhancements

### DIFF
--- a/IntuneBackupAndRestore/Public/Compare-IntuneBackupDirectories.ps1
+++ b/IntuneBackupAndRestore/Public/Compare-IntuneBackupDirectories.ps1
@@ -107,7 +107,7 @@
 			}
 
 			if (!$difFileFound) {
-				Write-Output "There is completely new setting, '$differenceJSONFile' which is located at $($file.FullPath)"
+				Write-Output "There is a new file. '$differenceJSONFile' which is located at $($file.FullPath)"
 			}
 		}
 	}

--- a/IntuneBackupAndRestore/Public/Compare-IntuneBackupDirectories.ps1
+++ b/IntuneBackupAndRestore/Public/Compare-IntuneBackupDirectories.ps1
@@ -48,7 +48,7 @@
 			$difFileFound = $differenceFiles | Where-Object { $_.FileName -eq $referenceJSONFile }
 			
 			if (($difFileFound.FileName).count -gt 1) {
-				$referenceJSONFile = ($file.Filename).split("\") | Select-Object -last 2
+				$referenceJSONFile = (($file.Filename).split("\") | Select-Object -last 2) -join "\"
 				$referenceJSONFileParent = ($file.FileName).split("\") | Select-Object -Last 2
 				$referenceJSONFileParentPath = "$(($referenceJSONFileParent).item(0))\$(($referenceJSONFileParent).item(1))"
 				Write-Verbose "Multiple difference files found that were matching the reference file"

--- a/IntuneBackupAndRestore/Public/Compare-IntuneBackupDirectories.ps1
+++ b/IntuneBackupAndRestore/Public/Compare-IntuneBackupDirectories.ps1
@@ -2,29 +2,29 @@
 	<#
     .SYNOPSIS
     Compare two Intune Backup Directories for changes in each of their JSON backup files.
-    
+
     .DESCRIPTION
     Compare two Intune Backup Directories for changes.
-    
+
     .PARAMETER $ReferenceDirectory
     Any Intune Backup Directory.
-    
+
     .PARAMETER $DifferenceDirectory
     Latest Intune Backup directory
-    
+
     .EXAMPLE
 	- Show verbose output
     Compare-IntuneBackupDirectories -Verbose -ReferenceDirectory C:\Users\BradleyWyatt\AppData\Local\Temp\IntuneBackup -DifferenceDirectory C:\Users\BradleyWyatt\AppData\Local\Temp\IntuneNewBackup
-	
+
 	Compare-IntuneBackupDirectories -ReferenceDirectory C:\Users\BradleyWyatt\AppData\Local\Temp\IntuneBackup -DifferenceDirectory C:\Users\BradleyWyatt\AppData\Local\Temp\IntuneNewBackup
-    
+
     .NOTES
     Requires the IntuneBackupAndRestore Module
-	
+
 	.AUTHOR
 	Bradley Wyatt - The Lazy Administrator
     #>
-	
+
 	param (
 		[parameter(Mandatory = $true, Position = 0)]
 		[String]$ReferenceDirectory,
@@ -34,31 +34,43 @@
 
 	begin {
 		$referenceFiles = Get-ChildItem $ReferenceDirectory -Recurse | Where-Object { $_.Name -like "*.json*" } | Select-Object -ExpandProperty VersionInfo
-		
+
 		$differenceFiles = Get-ChildItem $DifferenceDirectory -Recurse | Where-Object { $_.Name -like "*.json*" } | Select-Object @{ Label = "FileName"; Expression = { (($_.VersionInfo).FileName).split("\") | Select-Object -Last 1 } }, @{ Label = "FullPath"; Expression = { (($_.VersionInfo).FileName) } }
 	}
 
 	process	{
 		foreach ($file in $referenceFiles) {
 			$referenceJSONFile = ($file.Filename).split("\") | Select-Object -last 1
-			
+
 			Write-Verbose "The reference file is '$referenceJSONFile'"
 			Write-Verbose "The reference file path is $($file.FileName)"
-			
+
 			$difFileFound = $differenceFiles | Where-Object { $_.FileName -eq $referenceJSONFile }
-			
+
 			if (($difFileFound.FileName).count -gt 1) {
 				$referenceJSONFile = (($file.Filename).split("\") | Select-Object -last 2) -join "\"
 				$referenceJSONFileParent = ($file.FileName).split("\") | Select-Object -Last 2
-				$referenceJSONFileParentPath = "$(($referenceJSONFileParent).item(0))\$(($referenceJSONFileParent).item(1))"
+				$referenceJSONFileParentPath = $referenceJSONFileParent -join "\"
 				Write-Verbose "Multiple difference files found that were matching the reference file"
 				$difFileFound = $differenceFiles | Where-Object { $_.FullPath -like "*$referenceJSONFileParentPath*" }
+				if (($difFileFound.FileName).count -gt 1) {
+					# path wasn't precise enough to uniquely identify the correct difference file
+					# try to use last three parts of the file path instead of two
+					$referenceJSONFileParent = ($file.FileName).split("\") | Select-Object -Last 3
+					$referenceJSONFileParentPath = $referenceJSONFileParent -join "\"
+					Write-Verbose "Multiple difference files found again that were matching the reference file"
+					$difFileFound = $differenceFiles | Where-Object { $_.FullPath -like "*$referenceJSONFileParentPath*" }
+					if (($difFileFound.FileName).count -gt 1) {
+						Write-Warning "Unable to uniquely identify difference file. Skipping $referenceJSONFile"
+						continue
+					}
+				}
 			}
-			
+
 			Write-Verbose "The difference file is located at $($difFileFound.fullpath)"
-			
+
 			Write-Verbose "Checking for changes in the file '$referenceJSONFile'"
-			
+
 			$changes = Compare-IntuneBackupFile -ReferenceFilePath $file.FileName -DifferenceFilePath $difFileFound.FullPath -ErrorAction silentlycontinue
 			if ($changes) {
 				Write-Output "There was a change in the file, '$referenceJSONFile' which is located at $($difFileFound.fullpath)"

--- a/IntuneBackupAndRestore/Public/Compare-IntuneBackupDirectories.ps1
+++ b/IntuneBackupAndRestore/Public/Compare-IntuneBackupDirectories.ps1
@@ -71,7 +71,7 @@
 
 			Write-Verbose "Checking for changes in the file '$referenceJSONFile'"
 
-			$changes = Compare-IntuneBackupFile -ReferenceFilePath $file.FileName -DifferenceFilePath $difFileFound.FullPath -ErrorAction silentlycontinue
+			$changes = Compare-IntuneBackupFile -ReferenceFilePath $file.FileName -DifferenceFilePath $difFileFound.FullPath -ErrorAction "Continue"
 			if ($changes) {
 				Write-Output "There was a change in the file, '$referenceJSONFile' which is located at $($difFileFound.fullpath)"
 				$changes | Format-Table -AutoSize

--- a/IntuneBackupAndRestore/Public/Compare-IntuneBackupFile.ps1
+++ b/IntuneBackupAndRestore/Public/Compare-IntuneBackupFile.ps1
@@ -102,7 +102,7 @@ function Compare-IntuneBackupFile() {
         $flattenLatestBackupObject = New-Object -TypeName PSObject
         for ($i=0; $i -le $flattenLatestBackupArray.Length; $i++) {
             foreach ($property in $flattenLatestBackupArray[$i].PSObject.Properties) {
-                $flattenLatestBackupObject | Add-Member -NotePropertyName $property.Name -NotePropertyValue $property.Value
+                $flattenLatestBackupObject | Add-Member -NotePropertyName $property.Name -NotePropertyValue $property.Value -Force
             }
         }
     }

--- a/IntuneBackupAndRestore/Public/Compare-IntuneBackupFile.ps1
+++ b/IntuneBackupAndRestore/Public/Compare-IntuneBackupFile.ps1
@@ -62,8 +62,11 @@ function Compare-IntuneBackupFile() {
                 }
             }
             else {
-                if ($($_.Value).GetType().Name -eq 'PSCustomObject') {
+                if (($_.Value).GetType().Name -eq 'PSCustomObject') {
                     Invoke-FlattenBackupObject -PSCustomObject $_.Value -KeyName $_.Name
+                }
+                elseif (($_.Value).GetType().Name -eq 'Object[]') {
+                    Invoke-FlattenBackupObject -PSCustomObject $_.Value.GetEnumerator() -KeyName $_.Name
                 }
                 else {
                     if ($KeyName) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
@@ -1,0 +1,57 @@
+﻿function Invoke-IntuneBackupDeviceHealthScript {
+    <#
+    .SYNOPSIS
+    Backup Intune Health Scripts (Remediation scripts)
+
+    .DESCRIPTION
+    Backup Intune Health Scripts (Remediation scripts) as JSON files per Health Script to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .EXAMPLE
+    Invoke-IntuneBackupDeviceHealthScript -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Create folder if not exists
+    if (-not (Test-Path "$Path\Device Health Scripts")) {
+        $null = New-Item -Path "$Path\Device Health Scripts" -ItemType Directory
+    }
+
+    $healthScripts = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/deviceHealthScripts" | Select-Object -ExpandProperty Value
+
+    foreach ($healthScript in $healthScripts) {
+        $fileName = ($healthScript.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+
+        # Export the Health script profile
+        $healthScript | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$path\Device Health Scripts\$fileName.json"
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Device Health Scripts\Script Content")) {
+            $null = New-Item -Path "$Path\Device Health Scripts\Script Content" -ItemType Directory
+        }
+
+        $healthScriptObject = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/deviceHealthScripts/$($healthScript.id)"
+        $healthScriptDetectionContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($healthScriptObject.detectionScriptContent))
+        $healthScriptDetectionContent | Out-File -LiteralPath "$path\Device Health Scripts\Script Content\$fileName`_detection.ps1"
+        $healthScriptRemediationContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($healthScriptObject.remediationScriptContent))
+        $healthScriptRemediationContent | Out-File -LiteralPath "$path\Device Health Scripts\Script Content\$fileName`_detection.ps1"
+
+        [PSCustomObject]@{
+            "Action" = "Backup"
+            "Type"   = "Device Health Scripts"
+            "Name"   = $healthScript.displayName
+            "Path"   = "Device Health Scripts\$fileName.json"
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
@@ -45,7 +45,7 @@
         $healthScriptDetectionContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($healthScriptObject.detectionScriptContent))
         $healthScriptDetectionContent | Out-File -LiteralPath "$path\Device Health Scripts\Script Content\$fileName`_detection.ps1"
         $healthScriptRemediationContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($healthScriptObject.remediationScriptContent))
-        $healthScriptRemediationContent | Out-File -LiteralPath "$path\Device Health Scripts\Script Content\$fileName`_detection.ps1"
+        $healthScriptRemediationContent | Out-File -LiteralPath "$path\Device Health Scripts\Script Content\$fileName`_remediation.ps1"
 
         [PSCustomObject]@{
             "Action" = "Backup"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
@@ -1,0 +1,48 @@
+﻿function Invoke-IntuneBackupDeviceHealthScriptAssignment {
+    <#
+    .SYNOPSIS
+    Backup Intune Health Script (remediation Scripts) Assignments
+
+    .DESCRIPTION
+    Backup Intune Health Script (remediation Scripts) Assignments as JSON files per Health Script Policy to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .EXAMPLE
+    Invoke-IntuneBackupDeviceHealthScriptAssignment -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Create folder if not exists
+    if (-not (Test-Path "$Path\Device Health Scripts\Assignments")) {
+        $null = New-Item -Path "$Path\Device Health Scripts\Assignments" -ItemType Directory
+    }
+
+    $healthScripts = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/deviceHealthScripts" | Select-Object -ExpandProperty Value
+
+    foreach ($healthScript in $healthScripts) {
+        $assignments = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/deviceHealthScripts/$($healthScript.id)/assignments"
+
+        if ($assignments) {
+            $fileName = ($healthScript.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            $assignments | ConvertTo-Json | Out-File -LiteralPath "$path\Device Health Scripts\Assignments\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Device Health Scripts Assignments"
+                "Name"   = $healthScript.displayName
+                "Path"   = "Device Health Scripts\Assignments\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
@@ -2,22 +2,22 @@ function Start-IntuneBackup() {
     <#
     .SYNOPSIS
     Backup Intune Configuration
-    
+
     .DESCRIPTION
     Backup Intune Configuration
-    
+
     .PARAMETER Path
     Path to store backup (JSON) files.
-    
+
     .EXAMPLE
     Start-IntuneBackup -Path C:\temp
-    
+
     .NOTES
     Requires the MSGraphFunctions PowerShell Module
 
     Connect to MSGraph first, using the 'Connect-Graph' cmdlet.
     #>
-    
+
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -45,4 +45,6 @@ function Start-IntuneBackup() {
     Invoke-IntuneBackupGroupPolicyConfigurationAssignment -Path $Path
     Invoke-IntuneBackupDeviceManagementIntent -Path $Path
     Invoke-IntuneBackupAppProtectionPolicy -Path $Path
+    Invoke-IntuneBackupDeviceHealthScript -Path $Path
+    Invoke-IntuneBackupDeviceHealthScriptAssignment -Path $Path
 }


### PR DESCRIPTION
When multiple difference files are found, parent folder is added to file path, but resultant object is array of two items instead of string joined with '\'