### PR TITLE
Support RestoreById

### DIFF
--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
@@ -33,7 +33,7 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
     }
 
     # Get all App Protection Policies
-    $appProtectionPolicies = Get-ChildItem -Path "$path\App Protection Policies" -File
+    $appProtectionPolicies = Get-ChildItem -Path "$path\App Protection Policies" -File -Filter *.json
     
     foreach ($appProtectionPolicy in $appProtectionPolicies) {
         $appProtectionPolicyContent = Get-Content -LiteralPath $appProtectionPolicy.FullName -Raw
@@ -43,7 +43,7 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
         $requestBodyObject = $appProtectionPolicyContent | ConvertFrom-Json
         # Set SupportsScopeTags to $false, because $true currently returns an HTTP Status 400 Bad Request error.
         if ($requestBodyObject.supportsScopeTags) {
-            $requestBodyObject.supportsScopeTags = $false
+            #$requestBodyObject.supportsScopeTags = $false
         }
 
         $requestBodyObject.PSObject.Properties | Foreach-Object {
@@ -54,12 +54,12 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
             }
         }
 
-        $requestBody = $requestBodyObject | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, version | ConvertTo-Json -Depth 100
+        $requestBody = $requestBodyObject | Select-Object -Property * -ExcludeProperty createdDateTime, lastModifiedDateTime, version | ConvertTo-Json -Depth 100
 
         # Restore the App Protection Policy
         try {
             if($RestoreById)
-            { $null = Invoke-MSGraphRequest -HttpMethod PUT -Content $requestBody.toString() -Url "deviceManagement/managedAppPolicies/$($appProtectionPolicyContent.id)" -ErrorAction Stop }
+            { $null = Invoke-MSGraphRequest -HttpMethod PATCH -Content $requestBody.toString() -Url "deviceAppManagement/managedAppPolicies/$($requestBodyObject.id)" -ErrorAction Stop }
             else 
             { $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceAppManagement/managedAppPolicies" -ErrorAction Stop }
             

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
@@ -19,6 +19,9 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
         [string]$Path,
 
         [Parameter(Mandatory = $false)]
+        [bool]$RestoreById = $false,
+
+        [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
@@ -55,8 +58,11 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
 
         # Restore the App Protection Policy
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceAppManagement/managedAppPolicies" -ErrorAction Stop
-
+            if($RestoreById)
+            { $null = Invoke-MSGraphRequest -HttpMethod PUT -Content $requestBody.toString() -Url "deviceManagement/managedAppPolicies/$($appProtectionPolicyContent.id)" -ErrorAction Stop }
+            else 
+            { $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceAppManagement/managedAppPolicies" -ErrorAction Stop }
+            
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "App Protection Policy"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicyAssignment.ps1
@@ -37,7 +37,7 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
     }
 
     # Get all policies with assignments
-    $appProtectionPolicies = Get-ChildItem -Path "$Path\App Protection Policies\Assignments"
+    $appProtectionPolicies = Get-ChildItem -Path "$Path\App Protection Policies\Assignments" -Filter *.json
     foreach ($appProtectionPolicy in $appProtectionPolicies) {
         $appProtectionPolicyAssignments = Get-Content -LiteralPath $appProtectionPolicy.FullName | ConvertFrom-Json
         $appProtectionPolicyId = ($appProtectionPolicy.BaseName -split " - ")[0]

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreClientAppAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreClientAppAssignment.ps1
@@ -67,7 +67,7 @@ function Invoke-IntuneRestoreClientAppAssignment {
         }
 
         # Convert the PowerShell object to JSON
-        $requestBody = $requestBody | ConvertTo-Json -Depth 100
+        $requestBody = $requestBody | ConvertTo-Json -Depth 100 -Filter *.json
 
         # Get the Client App we are restoring the assignments for
         try {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicy.ps1
@@ -25,7 +25,7 @@ function Invoke-IntuneRestoreConfigurationPolicy {
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
-
+ 
     # Set the Microsoft Graph API endpoint
     if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
         Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
@@ -33,7 +33,7 @@ function Invoke-IntuneRestoreConfigurationPolicy {
     }
 
     # Get all Settings Catalog Policies
-    $configurationPolicies = Get-ChildItem -Path "$Path\Settings Catalog" -File
+    $configurationPolicies = Get-ChildItem -Path "$Path\Settings Catalog" -File -Filter *.json
 
     foreach ($configurationPolicy in $configurationPolicies) {
         $configurationPolicyContent = Get-Content -LiteralPath $configurationPolicy.FullName -Raw | ConvertFrom-Json

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicyAssignment.ps1
@@ -39,7 +39,7 @@ function Invoke-IntuneRestoreConfigurationPolicyAssignment {
     }
 
     # Get all policies with assignments
-    $configurationPolicies = Get-ChildItem -Path "$Path\Settings Catalog\Assignments"
+    $configurationPolicies = Get-ChildItem -Path "$Path\Settings Catalog\Assignments" -Filter *.json
     foreach ($configurationPolicy in $configurationPolicies) {
         $configurationPolicyAssignments = Get-Content -LiteralPath $configurationPolicy.FullName | ConvertFrom-Json
         $configurationPolicyId = ($configurationPolicyAssignments[0]).id.Split("_")[0]

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
@@ -19,6 +19,9 @@ function Invoke-IntuneRestoreDeviceCompliancePolicy {
         [string]$Path,
 
         [Parameter(Mandatory = $false)]
+        [bool]$RestoreById = $false,
+
+        [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
@@ -62,7 +65,11 @@ function Invoke-IntuneRestoreDeviceCompliancePolicy {
 
         # Restore the Device Compliance Policy
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceCompliancePolicies" -ErrorAction Stop
+            if($RestoreById)
+            { $null = Invoke-MSGraphRequest -HttpMethod PUT -Content $requestBody.toString() -Url "deviceManagement/deviceCompliancePolicies/$($deviceCompliancePolicyContent.id)" -ErrorAction Stop }
+            else 
+            { $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceCompliancePolicies" -ErrorAction Stop}
+            
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Compliance Policy"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicyAssignment.ps1
@@ -39,7 +39,7 @@ function Invoke-IntuneRestoreDeviceCompliancePolicyAssignment {
     }
 
     # Get all policies with assignments
-    $deviceCompliancePolicies = Get-ChildItem -Path "$Path\Device Compliance Policies\Assignments"
+    $deviceCompliancePolicies = Get-ChildItem -Path "$Path\Device Compliance Policies\Assignments" -Filter *.json
     foreach ($deviceCompliancePolicy in $deviceCompliancePolicies) {
         $deviceCompliancePolicyAssignments = Get-Content -LiteralPath $deviceCompliancePolicy.FullName | ConvertFrom-Json
         $deviceCompliancePolicyId = ($deviceCompliancePolicyAssignments[0]).id.Split("_")[0]

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
@@ -19,6 +19,9 @@ function Invoke-IntuneRestoreDeviceConfiguration {
         [string]$Path,
 
         [Parameter(Mandatory = $false)]
+        [bool]$RestoreById = $false,
+
+        [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
@@ -55,7 +58,11 @@ function Invoke-IntuneRestoreDeviceConfiguration {
 
         # Restore the device configuration
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceConfigurations" -ErrorAction Stop
+            if($RestoreById)
+            { $null = Invoke-MSGraphRequest -HttpMethod PUT -Content $requestBody.toString() -Url "deviceManagement/deviceConfigurations/$($deviceConfigurations.id)" -ErrorAction Stop }
+            else 
+            { $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceConfigurations" -ErrorAction Stop}
+            
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Configuration"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
@@ -33,7 +33,7 @@ function Invoke-IntuneRestoreDeviceConfiguration {
     }
 
     # Get all device configurations
-    $deviceConfigurations = Get-ChildItem -Path "$path\Device Configurations" -File
+    $deviceConfigurations = Get-ChildItem -Path "$path\Device Configurations" -File -Filter *.json
     
     foreach ($deviceConfiguration in $deviceConfigurations) {
         $deviceConfigurationContent = Get-Content -LiteralPath $deviceConfiguration.FullName -Raw
@@ -41,10 +41,6 @@ function Invoke-IntuneRestoreDeviceConfiguration {
 
         # Remove properties that are not available for creating a new configuration
         $requestBodyObject = $deviceConfigurationContent | ConvertFrom-Json
-        # Set SupportsScopeTags to $false, because $true currently returns an HTTP Status 400 Bad Request error.
-        if ($requestBodyObject.supportsScopeTags) {
-            $requestBodyObject.supportsScopeTags = $false
-        }
 
         $requestBodyObject.PSObject.Properties | Foreach-Object {
             if ($null -ne $_.Value) {
@@ -54,12 +50,12 @@ function Invoke-IntuneRestoreDeviceConfiguration {
             }
         }
 
-        $requestBody = $requestBodyObject | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, version | ConvertTo-Json -Depth 100
+        $requestBody = $requestBodyObject | Select-Object -Property * -ExcludeProperty Id, createdDateTime, lastModifiedDateTime, version, supportsScopeTags, qualityUpdatesPauseExpiryDateTime, featureUpdatesPauseExpiryDateTime, qualityUpdatesRollbackStartDateTime, featureUpdatesRollbackStartDateTime, qualityUpdatesPauseStartDate, featureUpdatesPauseStartDate, qualityUpdatesWillBeRolledBack, featureUpdatesWillBeRolledBack, featureUpdatesPaused, qualityUpdatesPaused | ConvertTo-Json -Depth 100
 
         # Restore the device configuration
         try {
             if($RestoreById)
-            { $null = Invoke-MSGraphRequest -HttpMethod PUT -Content $requestBody.toString() -Url "deviceManagement/deviceConfigurations/$($deviceConfigurations.id)" -ErrorAction Stop }
+            { $null = Invoke-MSGraphRequest -HttpMethod PATCH -Content $requestBody.toString() -Url "deviceManagement/deviceConfigurations/$(($deviceConfigurationContent | ConvertFrom-Json).id)" -ErrorAction Stop }
             else 
             { $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceConfigurations" -ErrorAction Stop}
             
@@ -72,6 +68,7 @@ function Invoke-IntuneRestoreDeviceConfiguration {
         }
         catch {
             Write-Verbose "$deviceConfigurationDisplayName - Failed to restore Device Configuration" -Verbose
+            Write-Output $(($deviceConfigurationContent | ConvertFrom-Json).id); Write-Output ""; Write-Output $requestBody.toString();
             Write-Error $_ -ErrorAction Continue
         }
     }

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfigurationAssignment.ps1
@@ -39,7 +39,7 @@ function Invoke-IntuneRestoreDeviceConfigurationAssignment {
     }
 
     # Get all policies with assignments
-    $deviceConfigurations = Get-ChildItem -Path "$Path\Device Configurations\Assignments"
+    $deviceConfigurations = Get-ChildItem -Path "$Path\Device Configurations\Assignments" -Filter *.json
     foreach ($deviceConfiguration in $deviceConfigurations) {
         $deviceConfigurationAssignments = Get-Content -LiteralPath $deviceConfiguration.FullName | ConvertFrom-Json
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
@@ -19,6 +19,9 @@ function Invoke-IntuneRestoreDeviceManagementIntent {
         [string]$Path,
 
         [Parameter(Mandatory = $false)]
+        [bool]$RestoreById = $false,
+
+        [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
@@ -30,21 +33,38 @@ function Invoke-IntuneRestoreDeviceManagementIntent {
     }
 
     # Get all device management intents
-    $deviceManagementIntents = Get-ChildItem -Path "$Path\Device Management Intents" -Recurse -File
+    $deviceManagementIntents = Get-ChildItem -Path "$Path\Device Management Intents" -Recurse -File -Filter *.json
     foreach ($deviceManagementIntent in $deviceManagementIntents) {
         $deviceManagementIntentContent = Get-Content -LiteralPath $deviceManagementIntent.FullName -Raw
         $deviceManagementIntentDisplayName = ($deviceManagementIntentContent | ConvertFrom-Json).displayName
         $templateId = $deviceManagementIntent.Name.Split("_")[0]
         $templateDisplayName = ($deviceManagementIntent).DirectoryName.Split('\')[-1]
 
+        if($RestoreById)
+        { 
+            # Get current ID of Intent
+            $deviceManagementIntentId = $null
+            $deviceManagementIntentId = ((Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/intents").Value | Where-Object{$_.displayName -eq $deviceManagementIntentDisplayName}).Id
+        }
+        
         # Restore the device management intent
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Url "deviceManagement/templates/$($templateId)/createInstance" -Content $deviceManagementIntentContent.toString() -ErrorAction Stop
-            [PSCustomObject]@{
-                "Action" = "Restore"
-                "Type"   = "Device Management Intent"
-                "Name"   = $deviceManagementIntentDisplayName
-                "Path"   = "Device Management Intents\$($deviceManagementIntent.Name)"
+            if($RestoreById -and $deviceManagementIntentId)
+            {   
+                if($deviceManagementIntentId.count -gt 1){Throw "Multiple Intents found with same Display Name - cannot continue"}
+                $deviceManagementIntentContent.toString()
+                $($deviceManagementIntentId)
+                $null = Invoke-MSGraphRequest -HttpMethod PATCH -Url "deviceManagement/intents/$($deviceManagementIntentId)" -Content $deviceManagementIntentContent.toString() -ErrorAction Stop
+            }
+            else 
+            {
+                $null = Invoke-MSGraphRequest -HttpMethod POST -Url "deviceManagement/templates/$($templateId)/createInstance" -Content $deviceManagementIntentContent.toString() -ErrorAction Stop
+                [PSCustomObject]@{
+                    "Action" = "Restore"
+                    "Type"   = "Device Management Intent"
+                    "Name"   = $deviceManagementIntentDisplayName
+                    "Path"   = "Device Management Intents\$($deviceManagementIntent.Name)"
+                }
             }
         }
         catch {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
@@ -19,6 +19,9 @@ function Invoke-IntuneRestoreDeviceManagementScript {
         [string]$Path,
 
         [Parameter(Mandatory = $false)]
+        [bool]$RestoreById = $false,
+
+        [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
@@ -41,7 +44,11 @@ function Invoke-IntuneRestoreDeviceManagementScript {
 
         # Restore the device management script
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceManagementScripts" -ErrorAction Stop
+            if($RestoreById)
+            { $null = Invoke-MSGraphRequest -HttpMethod PUT -Content $requestBody.toString() -Url "deviceManagement/deviceManagementScripts/$($deviceManagementScriptContent.id)" -ErrorAction Stop }
+            else 
+            { $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceManagementScripts" -ErrorAction Stop }
+            
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Management Script"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
@@ -22,6 +22,9 @@ function Invoke-IntuneRestoreDeviceManagementScript {
         [bool]$RestoreById = $false,
 
         [Parameter(Mandatory = $false)]
+        [bool]$ConvertPS1ToScriptContent = $true,
+
+        [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
@@ -33,21 +36,32 @@ function Invoke-IntuneRestoreDeviceManagementScript {
     }
 
     # Get all device management scripts
-    $deviceManagementScripts = Get-ChildItem -Path "$Path\Device Management Scripts" -File
+    $deviceManagementScripts = Get-ChildItem -Path "$Path\Device Management Scripts" -File -Filter *.json
     foreach ($deviceManagementScript in $deviceManagementScripts) {
         $deviceManagementScriptContent = Get-Content -LiteralPath $deviceManagementScript.FullName -Raw
         $deviceManagementScriptDisplayName = ($deviceManagementScriptContent | ConvertFrom-Json).displayName  
         
         # Remove properties that are not available for creating a new configuration
         $requestBodyObject = $deviceManagementScriptContent | ConvertFrom-Json
+        # Use PS1 file in "Script Content" folder
+        $ScriptPath = "$Path\Device Management Scripts\Script Content\$deviceManagementScriptDisplayName.ps1"
+        if(($ConvertPS1ToScriptContent) -and (Test-Path -Path $ScriptPath))
+        {
+            $ScriptContent = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Content -Path $ScriptPath -Raw -Encoding UTF8)))
+            $requestBodyObject.scriptContent = $ScriptContent
+
+        }
+        else {
+            Write-Output "ConvertPS1ToScriptContent was set to False or PS1 was not found"
+        }
         $requestBody = $requestBodyObject | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime | ConvertTo-Json
 
         # Restore the device management script
         try {
             if($RestoreById)
-            { $null = Invoke-MSGraphRequest -HttpMethod PUT -Content $requestBody.toString() -Url "deviceManagement/deviceManagementScripts/$($deviceManagementScriptContent.id)" -ErrorAction Stop }
+            {$null = Invoke-MSGraphRequest -HttpMethod PATCH -Content $requestBody.toString() -Url "deviceManagement/deviceManagementScripts/$(($deviceManagementScriptContent | ConvertFrom-Json).id)" -ErrorAction Stop}
             else 
-            { $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceManagementScripts" -ErrorAction Stop }
+            { $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceManagementScripts" -ErrorAction Stop}
             
             [PSCustomObject]@{
                 "Action" = "Restore"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScriptAssignment.ps1
@@ -39,7 +39,7 @@ function Invoke-IntuneRestoreDeviceManagementScriptAssignment {
     }
 
     # Get all policies with assignments
-    $deviceManagementScripts = Get-ChildItem -Path "$Path\Device Management Scripts\Assignments"
+    $deviceManagementScripts = Get-ChildItem -Path "$Path\Device Management Scripts\Assignments" -Filter *.json
     foreach ($deviceManagementScript in $deviceManagementScripts) {
         $deviceManagementScriptAssignments = Get-Content -LiteralPath $deviceManagementScript.FullName | ConvertFrom-Json
         $deviceManagementScriptId = ($deviceManagementScriptAssignments[0]).id.Split(":")[0]

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfiguration.ps1
@@ -41,7 +41,7 @@ function Invoke-IntuneRestoreGroupPolicyConfiguration {
         # Restore the Group Policy Configuration
         try {
             $groupPolicyConfigurationObject = $null
-            $groupPolicyConfigurationObject = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/groupPolicyConfigurations/" -ErrorAction Stop | Where-Object{$_.displayName -eq $groupPolicyConfiguration.BaseName}
+            $groupPolicyConfigurationObject = (Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/groupPolicyConfigurations/" -ErrorAction Stop).value | Where-Object{$_.displayName -eq $groupPolicyConfiguration.BaseName}
             if(!$groupPolicyConfigurationObject -or !$RestoreById){
                 $groupPolicyConfigurationRequestBody = @{
                     displayName = $groupPolicyConfiguration.BaseName

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfigurationAssignment.ps1
@@ -39,7 +39,7 @@ function Invoke-IntuneRestoreGroupPolicyConfigurationAssignment {
     }
 
     # Get all policies with assignments
-    $groupPolicyConfigurations = Get-ChildItem -Path "$Path\Administrative Templates\Assignments"
+    $groupPolicyConfigurations = Get-ChildItem -Path "$Path\Administrative Templates\Assignments" -Filter *.json
     foreach ($groupPolicyConfiguration in $groupPolicyConfigurations) {
         $groupPolicyConfigurationAssignments = Get-Content -LiteralPath $groupPolicyConfiguration.FullName | ConvertFrom-Json
         $groupPolicyConfigurationId = ($groupPolicyConfigurationAssignments[0]).id.Split("_")[0]

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
@@ -16,12 +16,17 @@ function Start-IntuneRestoreConfig() {
     Requires the MSGraphFunctions PowerShell Module
 
     Connect to MSGraph first, using the 'Connect-Graph' cmdlet.
+    
+    Set $RestoreById to $true, if the Configuration itself was not restored from backup. Set $RestoreById to $false if the configurations have been re-created (new unique ID's).
     #>
     
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Path
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$RestoreById = $false
     )
 
     [PSCustomObject]@{
@@ -31,11 +36,11 @@ function Start-IntuneRestoreConfig() {
         "Path"   = $Path
     }
 
-    Invoke-IntuneRestoreConfigurationPolicy -Path $Path
-    Invoke-IntuneRestoreDeviceCompliancePolicy -Path $Path
-    Invoke-IntuneRestoreDeviceConfiguration -Path $Path
-    Invoke-IntuneRestoreDeviceManagementScript -Path $Path
-    Invoke-IntuneRestoreGroupPolicyConfiguration -Path $Path
-    Invoke-IntuneRestoreDeviceManagementIntent -Path $Path
-    Invoke-IntuneRestoreAppProtectionPolicy -Path $Path
+    Invoke-IntuneRestoreConfigurationPolicy -Path $Path -RestoreById $RestoreById
+    Invoke-IntuneRestoreDeviceCompliancePolicy -Path $Path #-RestoreById $RestoreById
+    Invoke-IntuneRestoreDeviceConfiguration -Path $Path #-RestoreById $RestoreById
+    Invoke-IntuneRestoreDeviceManagementScript -Path $Path #-RestoreById $RestoreById
+    Invoke-IntuneRestoreGroupPolicyConfiguration -Path $Path #-RestoreById $RestoreById
+    Invoke-IntuneRestoreDeviceManagementIntent -Path $Path #-RestoreById $RestoreById
+    Invoke-IntuneRestoreAppProtectionPolicy -Path $Path #-RestoreById $RestoreById
 }

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
@@ -37,10 +37,10 @@ function Start-IntuneRestoreConfig() {
     }
 
     Invoke-IntuneRestoreConfigurationPolicy -Path $Path -RestoreById $RestoreById
-    Invoke-IntuneRestoreDeviceCompliancePolicy -Path $Path #-RestoreById $RestoreById
-    Invoke-IntuneRestoreDeviceConfiguration -Path $Path #-RestoreById $RestoreById
-    Invoke-IntuneRestoreDeviceManagementScript -Path $Path #-RestoreById $RestoreById
-    Invoke-IntuneRestoreGroupPolicyConfiguration -Path $Path #-RestoreById $RestoreById
-    Invoke-IntuneRestoreDeviceManagementIntent -Path $Path #-RestoreById $RestoreById
-    Invoke-IntuneRestoreAppProtectionPolicy -Path $Path #-RestoreById $RestoreById
+    Invoke-IntuneRestoreDeviceCompliancePolicy -Path $Path -RestoreById $RestoreById
+    Invoke-IntuneRestoreDeviceConfiguration -Path $Path -RestoreById $RestoreById
+    Invoke-IntuneRestoreDeviceManagementScript -Path $Path -RestoreById $RestoreById
+    Invoke-IntuneRestoreGroupPolicyConfiguration -Path $Path -RestoreById $RestoreById
+    Invoke-IntuneRestoreDeviceManagementIntent -Path $Path -RestoreById $RestoreById
+    Invoke-IntuneRestoreAppProtectionPolicy -Path $Path -RestoreById $RestoreById
 }


### PR DESCRIPTION
This change implements a new parameter to all part to the module: "RestoreById"
RestoreById will update/overwrite existing Intune configuration instead of creating new instances.
The purpose of this change is to support changes to existing configuration areas, without handling deleting old instances and ensuring assignments, and thus support configuration as code and deployment via automated pipelines.
 