### PR TITLE
Initial draft of backup/restore scripts for Autopilot Deployment Profiles

### DIFF
--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfile.ps1
@@ -1,0 +1,48 @@
+﻿function Invoke-IntuneBackupAutopilotDeploymentProfile {
+    <#
+    .SYNOPSIS
+    Backup Intune Autopilot Deployment Profiles
+
+    .DESCRIPTION
+    Backup Intune Autopilot Deployment Profiles as JSON files per deployment profile to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .EXAMPLE
+    Invoke-IntuneBackupAutopilotDeploymentProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Create folder if not exists
+    if (-not (Test-Path "$Path\Autopilot Deployment Profiles")) {
+        $null = New-Item -Path "$Path\Autopilot Deployment Profiles" -ItemType Directory
+    }
+
+    $winAutopilotDeploymentProfiles = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles" | Select-Object -ExpandProperty Value
+
+    foreach ($winAutopilotDeploymentProfile in $winAutopilotDeploymentProfiles) {
+        $fileName = ($winAutopilotDeploymentProfile.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+
+        # Export the Deployment profile
+		$winAutopilotDeploymentProfileObject = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfile.id)"
+		$winAutopilotDeploymentProfileObject | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$path\Autopilot Deployment Profiles\$fileName.json"
+
+		[PSCustomObject]@{
+			"Action" = "Backup"
+			"Type"   = "Autopilot Deployment Profile"
+			"Name"   = $winAutopilotDeploymentProfileObject.displayName
+			"Path"   = "Autopilot Deployment Profiles\$fileName.json"
+		}
+	
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfileAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfileAssignment.ps1
@@ -1,0 +1,55 @@
+﻿function Invoke-IntuneBackupAutopilotDeploymentProfileAssignment {
+    <#
+    .SYNOPSIS
+    Backup Intune Autopilot Deployment Profile Assignments
+    
+    .DESCRIPTION
+    Backup Intune Autopilot Deployment Profile Assignments as JSON files per Deployment Profile to the specified Path.
+    
+    .PARAMETER Path
+    Path to store backup files
+    
+    .EXAMPLE
+    Invoke-IntuneBackupAutopilotDeploymentProfileAssignment -Path "C:\temp"
+    #>
+    
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Set the Microsoft Graph API endpoint
+    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
+        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
+        Connect-MSGraph -ForceNonInteractive -Quiet
+    }
+
+    # Create folder if not exists
+    if (-not (Test-Path "$Path\Autopilot Deployment Profiles\Assignments")) {
+        $null = New-Item -Path "$Path\Autopilot Deployment Profiles\Assignments" -ItemType Directory
+    }
+
+    # Get all assignments from all policies
+    $winAutopilotDeploymentProfiles = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MSGraphAllPages
+
+    foreach ($winAutopilotDeploymentProfile in $winAutopilotDeploymentProfiles) {
+        $assignments = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfile.id)/assignments" | Get-MSGraphAllPages
+        
+        if ($assignments) {
+            $fileName = ($winAutopilotDeploymentProfile.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            $assignments | ConvertTo-Json | Out-File -LiteralPath "$path\Autopilot Deployment Profiles\Assignments\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Autopilot Deployment Profile Assignments"
+                "Name"   = $winAutopilotDeploymentProfile.displayName
+                "Path"   = "Autopilot Deployment Profiles\Assignments\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfile.ps1
@@ -1,0 +1,57 @@
+function Invoke-IntuneRestoreAutopilotDeploymentProfile {
+    <#
+    .SYNOPSIS
+    Restore Intune Autopilot Deployment Profiles
+    
+    .DESCRIPTION
+    Restore Intune Autopilot Deployment Profiles from JSON files per Deployment Profile from the specified Path.
+    
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupAutopilotDeploymentProfile function
+    
+    .EXAMPLE
+    Invoke-IntuneRestoreAutopilotDeploymentProfile -Path "C:\temp"
+    #>
+    
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Set the Microsoft Graph API endpoint
+    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
+        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
+        Connect-MSGraph -ForceNonInteractive -Quiet
+    }
+
+    # Get all device health scripts
+    $winAutopilotDeploymentProfiles = Get-ChildItem -Path "$Path\Autopilot Deployment Profiles" -File
+    foreach ($winAutopilotDeploymentProfile in $winAutopilotDeploymentProfiles) {
+        $winAutopilotDeploymentProfileContent = Get-Content -LiteralPath $winAutopilotDeploymentProfile.FullName -Raw
+        $winAutopilotDeploymentProfileDisplayName = ($winAutopilotDeploymentProfileContent | ConvertFrom-Json).displayName  
+        
+        # Remove properties that are not available for creating a new profile
+        $requestBodyObject = $winAutopilotDeploymentProfileContent | ConvertFrom-Json
+        $requestBody = $requestBodyObject | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime | ConvertTo-Json
+
+        # Restore the Deployment Profile
+		try {
+			$null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/windowsAutopilotDeploymentProfiles" -ErrorAction Stop
+			[PSCustomObject]@{
+				"Action" = "Restore"
+				"Type"   = "Autopilot Deployment Profile"
+				"Name"   = $winAutopilotDeploymentProfileDisplayName
+				"Path"   = "Autopilot Deployment Profiles\$($winAutopilotDeploymentProfile.Name)"
+			}
+		}
+		catch {
+			Write-Verbose "$winAutopilotDeploymentProfile - Failed to restore Autopilot Deployment Profile" -Verbose
+			Write-Error $_ -ErrorAction Continue
+		}
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment.ps1
@@ -1,0 +1,100 @@
+function Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment {
+    <#
+    .SYNOPSIS
+    Restore Intune Autopilot Deployment Profile Assignments
+    
+    .DESCRIPTION
+    Restore Intune Autopilot Deployment Profile Assignments from JSON files per profile from the specified Path.
+    
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupAutopilotDeploymentProfileAssignment function
+
+    .PARAMETER RestoreById
+    If RestoreById is set to true, assignments will be restored to Intune Autopilot Deployment Profiles that match the id.
+
+    If RestoreById is set to false, assignments will be restored to Intune Autopilot Deployment Profiles that match the file name.
+    This is necessary if the Autopilot Deployment Profile was restored from backup, because then a new Autopilot Deployment Profile is created with a new unique ID.
+    
+    .EXAMPLE
+    Invoke-IntuneRestoreDeviceHealthScriptAssignment -Path "C:\temp" -RestoreById $true
+    #>
+    
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$RestoreById = $false,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Set the Microsoft Graph API endpoint
+    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
+        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
+        Connect-MSGraph -ForceNonInteractive -Quiet
+    }
+
+    # Get all profiles with assignments
+    $winAutopilotDeploymentProfiles = Get-ChildItem -Path "$Path\Autopilot Deployment Profiles\Assignments"
+    foreach ($winAutopilotDeploymentProfile in $winAutopilotDeploymentProfiles) {
+        $winAutopilotDeploymentProfileAssignments = Get-Content -LiteralPath $winAutopilotDeploymentProfile.FullName | ConvertFrom-Json
+        $winAutopilotDeploymentProfileId = ($winAutopilotDeploymentProfileAssignments[0]).id.Split(":")[0]
+
+        # Create the base requestBody
+        $requestBody = @{
+            winAutopilotDeploymentProfileAssignments = @()
+        }
+        
+        # Add assignments to restore to the request body
+        foreach ($winAutopilotDeploymentProfileAssignment in $winAutopilotDeploymentProfileAssignments) {
+            $requestBody.winAutopilotDeploymentProfileAssignments += @{
+                "target" = $winAutopilotDeploymentProfileAssignment.target
+				"source" = $winAutopilotDeploymentProfileAssignment.source
+				"sourceId" = $winAutopilotDeploymentProfileAssignment.sourceId
+            }
+        }
+
+        # Convert the PowerShell object to JSON
+        $requestBody = $requestBody | ConvertTo-Json -Depth 100
+
+        # Get the Autopilot Deployment Profile we are restoring the assignments for
+        try {
+            if ($restoreById) {
+                $winAutopilotDeploymentProfileObject = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/windowsAutopilotDeploymentProfiles/$winAutopilotDeploymentProfileId"
+            }
+            else {
+                $winAutopilotDeploymentProfileObject = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MSGraphAllPages | Where-Object displayName -eq "$($winAutopilotDeploymentProfile.BaseName)"
+                if (-not ($winAutopilotDeploymentProfileObject)) {
+                    Write-Verbose "Error retrieving Intune Autopilot Deployment Profile for $($winAutopilotDeploymentProfile.FullName). Skipping assignment restore" -Verbose
+                    continue
+                }
+            }
+        }
+        catch {
+            Write-Verbose "Error retrieving Intune Autopilot Deployment Profile for $($winAutopilotDeploymentProfile.FullName). Skipping assignment restore" -Verbose
+            Write-Error $_ -ErrorAction Continue
+            continue
+        }
+
+        # Restore the assignments
+        try {
+			# FIXME: look into why POSTing to this Graph API endpoint currently results in error "403 Forbidden - FeatureNotEnabled",
+            # although the user account has the required permissions as documented in https://docs.microsoft.com/en-us/graph/api/intune-shared-windowsautopilotdeploymentprofile-assign?view=graph-rest-beta
+            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfileObject.id)/assign" -ErrorAction Stop
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Autopilot Deployment Profile Assignments"
+                "Name"   = $winAutopilotDeploymentProfileObject.displayName
+                "Path"   = "Autopilot Deployment Profiles\Assignments\$($winAutopilotDeploymentProfile.Name)"
+            }
+        }
+        catch {
+            Write-Verbose "$($winAutopilotDeploymentObject.displayName) - Failed to restore Autopilot Deployment Profile Assignment(s)" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}


### PR DESCRIPTION
Both backup and restore works for Windows Autopilot Deployment Profiles. The associated assignments can only be backed up at the moment, not restored, due to an issue with the associated Graph API endpoint (see FIXME comment in Public/Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment.ps1).

I initially wanted to also include backup/restore functionality for Enrollment Status Pages, but I could not find a suitable Graph API endpoint for this on short notice.