### PR TITLE
Fixed reuse of last encrypted value for non-encrypted fields.

### DIFF
--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
@@ -49,6 +49,8 @@ function Invoke-IntuneBackupDeviceConfiguration {
                 # Check if this particular setting is encrypted, and get the plaintext only if necessary
                 if ($omaSetting.isEncrypted) {
                     $omaSettingValue = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/deviceConfigurations/$($deviceConfiguration.id)/getOmaSettingPlainTextValue(secretReferenceValueId='$($omaSetting.secretReferenceValueId)')" | Get-MSGraphAllPages
+                } else {
+                    $omaSettingValue = $omaSetting.value
                 }
                 # Define a new 'unencrypted' OMA Setting
                 $newOmaSetting = @{}


### PR DESCRIPTION
Probably fixes https://github.com/jseerden/IntuneBackupAndRestore/issues/53

For non-encrypted fields (i.e. non-string), the field's value was never used. Instead, the (decrypted) value of the last encrypted field (i.e. string field) was used. Unsure what used to happen if the first field was non-encrypted, as I lack PowerShell experience and did not have time to test. Anyway, it works properly now.