### PR TITLE
Conversion from MSGraph module to MGGraph (Move to MSAL and enable Posh7 compatibility) 

### DIFF
--- a/IntuneBackupAndRestore/Private/Get-MGGraphAllPages.ps1
+++ b/IntuneBackupAndRestore/Private/Get-MGGraphAllPages.ps1
@@ -1,0 +1,41 @@
+function Get-MGGraphAllPages {
+    <#
+    .SYNOPSIS
+    Retrieve all pages of a Microsoft Graph Query
+    
+    .DESCRIPTION
+    Retrieve all pages of a Microsoft Graph Query
+    
+    .PARAMETER GraphResults
+    Microsoft Graph Query Results
+    
+    .EXAMPLE
+    Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations" | Get-MGGraphAllPages
+    
+    #>
+    
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline)]$GraphResults
+    )
+    $uri = $null
+    $QueryResults = @()
+    do {
+        if($uri){$GraphResults = Invoke-MgGraphRequest -uri "$uri"}
+        if ($GraphResults.value) {
+            $QueryResults += $GraphResults.value
+        }
+        else {
+            $QueryResults += $GraphResults
+        }
+        $uri = $GraphResults.'@odata.nextlink'
+    } until (!($uri))
+
+    #Check for null Value
+    if(($QueryResults.count -eq 2) -and ([string]::IsNullOrEmpty($QueryResults.value)) -and ($QueryResults.'@odata.context' -match "https://graph.microsoft.com/")) {
+        $QueryResults = $null
+    }
+
+    return $QueryResults
+    
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientApp.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientApp.ps1
@@ -22,11 +22,15 @@ function Invoke-IntuneBackupClientApp {
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
+    
+    #Connect to MS-Graph if required
+    if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
 
     # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
     }
 
     # Create folder if not exists
@@ -35,14 +39,15 @@ function Invoke-IntuneBackupClientApp {
     }
 
     # Get all Client Apps
-    $clientApps = Invoke-MSGraphRequest -Url 'deviceAppManagement/mobileApps?$filter=(microsoft.graph.managedApp/appAvailability%20eq%20null%20or%20microsoft.graph.managedApp/appAvailability%20eq%20%27lineOfBusiness%27%20or%20isAssigned%20eq%20true)' | Get-MSGraphAllPages
+    $filter = "microsoft.graph.managedApp/appAvailability eq null or microsoft.graph.managedApp/appAvailability eq 'lineOfBusiness' or isAssigned eq true"
+    $clientApps = Invoke-MgRestMethod -Uri "$apiversion/deviceAppManagement/mobileApps?filter=$filter" | Get-MgGraphAllPages
 
     foreach ($clientApp in $clientApps) {
         $clientAppType = $clientApp.'@odata.type'.split('.')[-1]
 
         $fileName = ($clientApp.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
-        $clientAppDetails = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceAppManagement/mobileApps/$($clientApp.id)"
-        $clientAppDetails | ConvertTo-Json | Out-File -LiteralPath "$path\Client Apps\$($clientAppType)_$($fileName).json"
+        $clientAppDetails =  Invoke-MgRestMethod -Uri "$apiversion/deviceAppManagement/mobileApps/$($clientApp.id)"
+        $clientAppDetails | ConvertTo-Json -depth 3 | Out-File -LiteralPath "$path\Client Apps\$($clientAppType)_$($fileName).json" 
 
         [PSCustomObject]@{
             "Action" = "Backup"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientAppAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientAppAssignment.ps1
@@ -23,22 +23,28 @@ function Invoke-IntuneBackupClientAppAssignment {
         [string]$ApiVersion = "Beta"
     )
 
-    # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    #Connect to MS-Graph if required
+    if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
     }
+
+    # Set the Microsoft Graph API endpoint
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
+    }
+
 
     # Create folder if not exists
     if (-not (Test-Path "$Path\Client Apps\Assignments")) {
         $null = New-Item -Path "$Path\Client Apps\Assignments" -ItemType Directory
     }
 
-    # Get all assignments from all policies
-    $clientApps = Invoke-MSGraphRequest -Url 'deviceAppManagement/mobileApps?$filter=(microsoft.graph.managedApp/appAvailability%20eq%20null%20or%20microsoft.graph.managedApp/appAvailability%20eq%20%27lineOfBusiness%27%20or%20isAssigned%20eq%20true)' | Get-MSGraphAllPages
+     # Get all Client Apps
+     $filter = "microsoft.graph.managedApp/appAvailability eq null or microsoft.graph.managedApp/appAvailability eq 'lineOfBusiness' or isAssigned eq true"
+     $clientApps = Invoke-MgRestMethod -Uri "$apiversion/deviceAppManagement/mobileApps?filter=$filter" | Get-MgGraphAllPages
 
     foreach ($clientApp in $clientApps) {
-        $assignments = Get-DeviceAppManagement_MobileApps_Assignments -MobileAppId $clientApp.id 
+        $assignments = (Invoke-MgRestMethod -Uri "/$apiversion/deviceAppManagement/mobileApps/$($clientApp.id)/assignments").value
         if ($assignments) {
             $fileName = ($clientApp.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
             $assignments | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$path\Client Apps\Assignments\$($clientApp.id) - $fileName.json"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
@@ -23,10 +23,14 @@ function Invoke-IntuneBackupDeviceConfiguration {
         [string]$ApiVersion = "Beta"
     )
 
+    #Connect to MS-Graph if required
+    if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
+
     # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
     }
 
     # Create folder if not exists
@@ -35,7 +39,7 @@ function Invoke-IntuneBackupDeviceConfiguration {
     }
 
     # Get all device configurations
-    $deviceConfigurations = Get-DeviceManagement_DeviceConfigurations | Get-MSGraphAllPages
+    $deviceConfigurations = Invoke-MgGraphRequest -Uri "$apiVersion/deviceManagement/deviceConfigurations" | Get-MGGraphAllPages
     
 
     foreach ($deviceConfiguration in $deviceConfigurations) {
@@ -48,7 +52,7 @@ function Invoke-IntuneBackupDeviceConfiguration {
             foreach ($omaSetting in $deviceConfiguration.omaSettings) {
                 # Check if this particular setting is encrypted, and get the plaintext only if necessary
                 if ($omaSetting.isEncrypted) {
-                    $omaSettingValue = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/deviceConfigurations/$($deviceConfiguration.id)/getOmaSettingPlainTextValue(secretReferenceValueId='$($omaSetting.secretReferenceValueId)')" | Get-MSGraphAllPages
+                    $omaSettingValue = Invoke-MgGraphRequest -Uri "$apiVersion/deviceManagement/deviceConfigurations/$($deviceConfiguration.id)/getOmaSettingPlainTextValue(secretReferenceValueId='$($omaSetting.secretReferenceValueId)')" | Get-MgGraphAllPages
                 }
                 # Define a new 'unencrypted' OMA Setting
                 $newOmaSetting = @{}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
@@ -12,7 +12,6 @@
     .EXAMPLE
     Invoke-IntuneBackupDeviceHealthScript -Path "C:\temp"
     #>
-
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -22,13 +21,22 @@
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
+    
+    #Connect to MS-Graph if required
+    if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
 
+    # Set the Microsoft Graph API endpoint
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
+    }
     # Create folder if not exists
     if (-not (Test-Path "$Path\Device Health Scripts")) {
         $null = New-Item -Path "$Path\Device Health Scripts" -ItemType Directory
     }
 
-    $healthScripts = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/deviceHealthScripts" | Select-Object -ExpandProperty Value
+    $healthScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceHealthScripts" | Get-MGGraphAllPages
 
     foreach ($healthScript in $healthScripts) {
         $fileName = ($healthScript.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
@@ -41,7 +49,7 @@
             $null = New-Item -Path "$Path\Device Health Scripts\Script Content" -ItemType Directory
         }
 
-        $healthScriptObject = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/deviceHealthScripts/$($healthScript.id)"
+        $healthScriptObject = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceHealthScripts/$($healthScript.id)"
         $healthScriptDetectionContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($healthScriptObject.detectionScriptContent))
         $healthScriptDetectionContent | Out-File -LiteralPath "$path\Device Health Scripts\Script Content\$fileName`_detection.ps1"
         $healthScriptRemediationContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($healthScriptObject.remediationScriptContent))

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
@@ -23,19 +23,29 @@
         [string]$ApiVersion = "Beta"
     )
 
+     #Connect to MS-Graph if required
+     if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
+
+    # Set the Microsoft Graph API endpoint
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
+    }
     # Create folder if not exists
     if (-not (Test-Path "$Path\Device Health Scripts\Assignments")) {
         $null = New-Item -Path "$Path\Device Health Scripts\Assignments" -ItemType Directory
     }
 
-    $healthScripts = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/deviceHealthScripts" | Select-Object -ExpandProperty Value
+    $healthScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceHealthScripts" | Get-MGGraphAllPages
 
     foreach ($healthScript in $healthScripts) {
-        $assignments = Invoke-MSGraphRequest -Url "https://graph.microsoft.com/$ApiVersion/deviceManagement/deviceHealthScripts/$($healthScript.id)/assignments"
+
+        $assignments = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceHealthScripts/$($healthScript.id)/assignments"
 
         if ($assignments) {
             $fileName = ($healthScript.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
-            $assignments | ConvertTo-Json | Out-File -LiteralPath "$path\Device Health Scripts\Assignments\$fileName.json"
+            $assignments | ConvertTo-Json -depth 100| Out-File -LiteralPath "$path\Device Health Scripts\Assignments\$fileName.json"
 
             [PSCustomObject]@{
                 "Action" = "Backup"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
@@ -12,7 +12,6 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
     .EXAMPLE
     Invoke-IntuneRestoreAppProtectionPolicy -Path "C:\temp" -RestoreById $true
     #>
-    
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -23,21 +22,25 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
         [string]$ApiVersion = "Beta"
     )
 
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
+
     # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
     }
 
     # Get all App Protection Policies
     $appProtectionPolicies = Get-ChildItem -Path "$path\App Protection Policies" -File
     
     foreach ($appProtectionPolicy in $appProtectionPolicies) {
-        $appProtectionPolicyContent = Get-Content -LiteralPath $appProtectionPolicy.FullName -Raw
-        $appProtectionPolicyDisplayName = ($appProtectionPolicyContent | ConvertFrom-Json).displayName
+        $appProtectionPolicyContent = Get-Content -LiteralPath $appProtectionPolicy.FullName | convertfrom-json
+        $appProtectionPolicyDisplayName = $appProtectionPolicyContent.displayName
 
         # Remove properties that are not available for creating a new configuration
-        $requestBodyObject = $appProtectionPolicyContent | ConvertFrom-Json
+        $requestBodyObject = $appProtectionPolicyContent
         # Set SupportsScopeTags to $false, because $true currently returns an HTTP Status 400 Bad Request error.
         if ($requestBodyObject.supportsScopeTags) {
             $requestBodyObject.supportsScopeTags = $false
@@ -55,7 +58,7 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
 
         # Restore the App Protection Policy
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceAppManagement/managedAppPolicies" -ErrorAction Stop
+            $null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceAppManagement/managedAppPolicies" -ErrorAction Stop
 
             [PSCustomObject]@{
                 "Action" = "Restore"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicyAssignment.ps1
@@ -16,7 +16,7 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
     .EXAMPLE
     Invoke-IntuneRestoreAppProtectionPolicyAssignment -Path "C:\temp" -RestoreById $true
     #>
-    
+
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -30,10 +30,14 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
         [string]$ApiVersion = "Beta"
     )
 
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
+
     # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
     }
 
     # Get all policies with assignments
@@ -41,8 +45,8 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
     foreach ($appProtectionPolicy in $appProtectionPolicies) {
         $appProtectionPolicyAssignments = Get-Content -LiteralPath $appProtectionPolicy.FullName | ConvertFrom-Json
         $appProtectionPolicyId = ($appProtectionPolicy.BaseName -split " - ")[0]
-        $appProtectionPolicyName = ($appProtectionPolicy.BaseName -split " - ",2)[-1]
-
+        $appProtectionPolicyName = (($appProtectionPolicy.BaseName -split " - ", 2)[-1])
+        
         # Create the base requestBody
         $requestBody = @{
             assignments = @()
@@ -51,7 +55,7 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
         # Add assignments to restore to the request body
         foreach ($appProtectionPolicyAssignment in $appProtectionPolicyAssignments.Value) {
             $requestBody.assignments += @{
-                "target"   = $appProtectionPolicyAssignment.target | Select-Object -Property * -ExcludeProperty deviceAndAppManagementAssignmentFilterId, deviceAndAppManagementAssignmentFilterType
+                "target" = $appProtectionPolicyAssignment.target | Select-Object -Property * -ExcludeProperty deviceAndAppManagementAssignmentFilterId, deviceAndAppManagementAssignmentFilterType
             }
         }
 
@@ -61,10 +65,10 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
         # Get the App Protection Policy we are restoring the assignments for
         try {
             if ($restoreById) {
-                $appProtectionPolicyObject = Get-IntuneAppProtectionPolicy -managedAppPolicyId $appProtectionPolicyId
+                $appProtectionPolicyObject = Invoke-MgGraphRequest -Uri "/$ApiVersion/deviceAppManagement/managedAppPolicies/$appProtectionPolicyId" 
             }
             else {
-                $appProtectionPolicyObject = Get-IntuneAppProtectionPolicy | Get-MSGraphAllPages | Where-Object { $_.displayName -eq $appProtectionPolicyName }
+                $appProtectionPolicyObject = Invoke-MgGraphRequest -Uri "/$ApiVersion/deviceAppManagement/managedAppPolicies/" | Get-MGGraphAllPages | Where-Object { $_.displayName -eq $appProtectionPolicyName }
                 if (-not ($appProtectionPolicyObject)) {
                     Write-Warning "Error retrieving App Protection Policy for $appProtectionPolicyName. Skipping assignment restore"
                     continue
@@ -81,19 +85,19 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
         try {
             # If Android
             if ($appProtectionPolicyObject.'@odata.type' -eq '#microsoft.graph.androidManagedAppProtection') {
-                $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceAppManagement/androidManagedAppProtections/$($appProtectionPolicyObject.id)/assign" -ErrorAction Stop
+                $null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceAppManagement/androidManagedAppProtections/$($appProtectionPolicyObject.id)/assign" -ErrorAction Stop
             }
             # Elseif iOS
             elseif ($appProtectionPolicyObject.'@odata.type' -eq '#microsoft.graph.iosManagedAppProtection') {
-                $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceAppManagement/iosManagedAppProtections/$($appProtectionPolicyObject.id)/assign" -ErrorAction Stop
+                $null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceAppManagement/iosManagedAppProtections/$($appProtectionPolicyObject.id)/assign" -ErrorAction Stop
             }
             # Elseif Windows 10 with enrollment
             elseif ($appProtectionPolicyObject.'@odata.type' -eq '#microsoft.graph.mdmWindowsInformationProtectionPolicy') {
-                $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceAppManagement/mdmWindowsInformationProtectionPolicies/$($appProtectionPolicyObject.id)/assign" -ErrorAction Stop
+                $null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceAppManagement/mdmWindowsInformationProtectionPolicies/$($appProtectionPolicyObject.id)/assign" -ErrorAction Stop
             }
             # Elseif Windows 10 without Enrollment
             elseif ($appProtectionPolicyObject.'@odata.type' -eq '#microsoft.graph.windowsInformationProtectionPolicy') {
-                $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceAppManagement/windowsInformationProtectionPolicies/$($appProtectionPolicyObject.id)/assign" -ErrorAction Stop
+                $null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceAppManagement/windowsInformationProtectionPolicies/$($appProtectionPolicyObject.id)/assign" -ErrorAction Stop
             }
 
             [PSCustomObject]@{

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicyAssignment.ps1
@@ -18,7 +18,6 @@ function Invoke-IntuneRestoreConfigurationPolicyAssignment {
     .EXAMPLE
     Invoke-IntuneBackupConfigurationPolicyAssignment -Path "C:\temp" -RestoreById $true
     #>
-    
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -32,17 +31,21 @@ function Invoke-IntuneRestoreConfigurationPolicyAssignment {
         [string]$ApiVersion = "Beta"
     )
 
-    # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    #Connect to MS-Graph if required
+    if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
     }
 
+    # Set the Microsoft Graph API endpoint
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
+    }
     # Get all policies with assignments
     $configurationPolicies = Get-ChildItem -Path "$Path\Settings Catalog\Assignments"
     foreach ($configurationPolicy in $configurationPolicies) {
         $configurationPolicyAssignments = Get-Content -LiteralPath $configurationPolicy.FullName | ConvertFrom-Json
         $configurationPolicyId = ($configurationPolicyAssignments[0]).id.Split("_")[0]
+        $configurationPolicyName = $($configurationPolicy.Name).split(".json")[0]
 
         # Create the base requestBody
         $requestBody = @{
@@ -62,10 +65,10 @@ function Invoke-IntuneRestoreConfigurationPolicyAssignment {
         # Get the Configuration Policy we are restoring the assignments for
         try {
             if ($restoreById) {
-                $configurationPolicyObject = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/configurationPolicies/$configurationPolicyId"
+                $configurationPolicyObject = Invoke-MgGraphRequest -method GET -Uri "$apiVersion/deviceManagement/configurationPolicies/$configurationPolicyId"
             }
             else {
-                $configurationPolicyObject = Invoke-MSGraphRequest -HttpMethod GET -Url "deviceManagement/configurationPolicies" | Get-MSGraphAllPages | Where-Object name -eq "$($configurationPolicy.BaseName)"
+                $configurationPolicyObject =  Invoke-MgGraphRequest -method GET -Uri "$apiVersion/deviceManagement/configurationPolicies" | Get-MgGraphAllPages | Where-Object name -eq $configurationPolicyName 
                 if (-not ($configurationPolicyObject)) {
                     Write-Verbose "Error retrieving Intune Session Catalog for $($configurationPolicy.FullName). Skipping assignment restore" -Verbose
                     continue
@@ -80,7 +83,7 @@ function Invoke-IntuneRestoreConfigurationPolicyAssignment {
 
         # Restore the assignments
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/configurationPolicies/$($configurationPolicyObject.id)/assign" -ErrorAction Stop
+            $null = Invoke-MgGraphRequest -method POST -body $requestBody.toString() -Uri "$apiVersion/deviceManagement/configurationPolicies/$($configurationPolicyObject.id)/assign" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Settings Catalog Assignments"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
@@ -20,28 +20,35 @@ function Invoke-IntuneRestoreDeviceCompliancePolicy {
 
         [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
-        [string]$ApiVersion = "Beta"
+        [string]$ApiVersion = "Beta",
+
+        [Parameter(Mandatory = $false)]
+        [string]$Prefix
     )
 
-    # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+     #Connect to MS-Graph if required
+     if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All" 
     }
+
+    # Set the Microsoft Graph API endpoint
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
+    }
+
 
     # Get all Device Compliance Policies
     $deviceCompliancePolicies = Get-ChildItem -Path "$Path\Device Compliance Policies" -File
     foreach ($deviceCompliancePolicy in $deviceCompliancePolicies) {
-        $deviceCompliancePolicyContent = Get-Content -LiteralPath $deviceCompliancePolicy.FullName -Raw
-        $deviceCompliancePolicyDisplayName = ($deviceCompliancePolicyContent | ConvertFrom-Json).displayName
+        $deviceCompliancePolicyContent = Get-Content -LiteralPath $deviceCompliancePolicy.FullName  -Raw | ConvertFrom-Json
+
+        $deviceCompliancePolicyDisplayName = $deviceCompliancePolicyContent.displayName
 
         # Remove properties that are not available for creating a new configuration
-        $requestBodyObject = $deviceCompliancePolicyContent | ConvertFrom-Json
-        $requestBody = $requestBodyObject | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime | ConvertTo-Json -Depth 100
+        $requestBody = $deviceCompliancePolicyContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime 
 
         # If missing, adds a default required block scheduled action to the compliance policy request body, as this value is not returned when retrieving compliance policies.
-        $requestBodyObject = $requestBody | ConvertFrom-Json
-        if (-not ($requestBodyObject.scheduledActionsForRule)) {
+        if (-not ($requestBody.scheduledActionsForRule)) {
             $scheduledActionsForRule = @(
                 @{
                     ruleName = "PasswordRequired"
@@ -54,15 +61,14 @@ function Invoke-IntuneRestoreDeviceCompliancePolicy {
                     )
                 }
             )
-            $requestBodyObject | Add-Member -NotePropertyName scheduledActionsForRule -NotePropertyValue $scheduledActionsForRule
-            
-            # Update the request body reflecting the changes
-            $requestBody = $requestBodyObject | ConvertTo-Json -Depth 100
+            $requestBody | Add-Member -NotePropertyName scheduledActionsForRule -NotePropertyValue $scheduledActionsForRule
         }
+        
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
 
         # Restore the Device Compliance Policy
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceCompliancePolicies" -ErrorAction Stop
+            $null = Invoke-MgGraphRequest -Method POST -body $requestBodyJson.toString() -Uri "beta/deviceManagement/deviceCompliancePolicies" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Compliance Policy"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
@@ -20,10 +20,7 @@ function Invoke-IntuneRestoreDeviceCompliancePolicy {
 
         [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
-        [string]$ApiVersion = "Beta",
-
-        [Parameter(Mandatory = $false)]
-        [string]$Prefix
+        [string]$ApiVersion = "Beta"
     )
 
      #Connect to MS-Graph if required

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicyAssignment.ps1
@@ -18,7 +18,6 @@ function Invoke-IntuneRestoreDeviceCompliancePolicyAssignment {
     .EXAMPLE
     Invoke-IntuneRestoreDeviceCompliancePolicyAssignment -Path "C:\temp" -RestoreById $true
     #>
-    
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -32,10 +31,14 @@ function Invoke-IntuneRestoreDeviceCompliancePolicyAssignment {
         [string]$ApiVersion = "Beta"
     )
 
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
+
     # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
     }
 
     # Get all policies with assignments
@@ -43,6 +46,7 @@ function Invoke-IntuneRestoreDeviceCompliancePolicyAssignment {
     foreach ($deviceCompliancePolicy in $deviceCompliancePolicies) {
         $deviceCompliancePolicyAssignments = Get-Content -LiteralPath $deviceCompliancePolicy.FullName | ConvertFrom-Json
         $deviceCompliancePolicyId = ($deviceCompliancePolicyAssignments[0]).id.Split("_")[0]
+        $deviceCompliancePolicyName = $deviceCompliancePolicy.BaseName 
 
         # Create the base requestBody
         $requestBody = @{
@@ -62,10 +66,10 @@ function Invoke-IntuneRestoreDeviceCompliancePolicyAssignment {
         # Get the Device Compliance Policy we are restoring the assignments for
         try {
             if ($restoreById) {
-                $deviceCompliancePolicyObject = Get-DeviceManagement_DeviceCompliancePolicies -DeviceCompliancePolicyId $deviceCompliancePolicyId
+                $deviceCompliancePolicyObject = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceCompliancePolicies/$deviceCompliancePolicyId" | Get-MGGraphAllPages
             }
             else {
-                $deviceCompliancePolicyObject = Get-DeviceManagement_DeviceCompliancePolicies | Get-MSGraphAllPages | Where-Object displayName -eq "$($deviceCompliancePolicy.BaseName)"
+                $deviceCompliancePolicyObject = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceCompliancePolicies" | Get-MGGraphAllPages | Where-Object displayName -eq $deviceCompliancePolicyName
                 if (-not ($deviceCompliancePolicyObject)) {
                     Write-Verbose "Error retrieving Intune Compliance Policy for $($deviceCompliancePolicy.FullName). Skipping assignment restore" -Verbose
                     continue
@@ -80,7 +84,7 @@ function Invoke-IntuneRestoreDeviceCompliancePolicyAssignment {
 
         # Restore the assignments
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceCompliancePolicies/$($deviceCompliancePolicyObject.id)/assign" -ErrorAction Stop
+            $null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceManagement/deviceCompliancePolicies/$($deviceCompliancePolicyObject.id)/assign" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Compliance Policy Assignments"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
@@ -23,21 +23,26 @@ function Invoke-IntuneRestoreDeviceConfiguration {
         [string]$ApiVersion = "Beta"
     )
 
+    #Connect to MS-Graph if required
+    if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
+
     # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
     }
 
     # Get all device configurations
     $deviceConfigurations = Get-ChildItem -Path "$path\Device Configurations" -File
     
     foreach ($deviceConfiguration in $deviceConfigurations) {
-        $deviceConfigurationContent = Get-Content -LiteralPath $deviceConfiguration.FullName -Raw
-        $deviceConfigurationDisplayName = ($deviceConfigurationContent | ConvertFrom-Json).displayName
+        $deviceConfigurationContent = Get-Content -LiteralPath $deviceConfiguration.FullName -Raw | ConvertFrom-Json
+
+        $deviceConfigurationDisplayName = $deviceConfigurationContent.displayName
 
         # Remove properties that are not available for creating a new configuration
-        $requestBodyObject = $deviceConfigurationContent | ConvertFrom-Json
+        $requestBodyObject = $deviceConfigurationContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, version
         # Set SupportsScopeTags to $false, because $true currently returns an HTTP Status 400 Bad Request error.
         if ($requestBodyObject.supportsScopeTags) {
             $requestBodyObject.supportsScopeTags = $false
@@ -51,11 +56,11 @@ function Invoke-IntuneRestoreDeviceConfiguration {
             }
         }
 
-        $requestBody = $requestBodyObject | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, version | ConvertTo-Json -Depth 100
+        $requestBody = $requestBodyObject  | ConvertTo-Json -Depth 100
 
         # Restore the device configuration
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceConfigurations" -ErrorAction Stop
+            $null = Invoke-MgGraphRequest -Method POST -body $requestBody.toString() -Uri "$ApiVersion/deviceManagement/deviceConfigurations" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Configuration"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfigurationAssignment.ps1
@@ -32,16 +32,21 @@ function Invoke-IntuneRestoreDeviceConfigurationAssignment {
         [string]$ApiVersion = "Beta"
     )
 
+    #Connect to MS-Graph if required
+    if($null -eq (Get-MgContext)){
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
+
     # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
     }
 
     # Get all policies with assignments
     $deviceConfigurations = Get-ChildItem -Path "$Path\Device Configurations\Assignments"
     foreach ($deviceConfiguration in $deviceConfigurations) {
         $deviceConfigurationAssignments = Get-Content -LiteralPath $deviceConfiguration.FullName | ConvertFrom-Json
+        $deviceConfigurationName = $deviceConfiguration.BaseName
 
         # Create the base requestBody
         $requestBody = @{
@@ -61,10 +66,10 @@ function Invoke-IntuneRestoreDeviceConfigurationAssignment {
         # Get the Device Configuration we are restoring the assignments for
         try {
             if ($restoreById) {
-                $deviceConfigurationObject = Get-DeviceManagement_DeviceConfigurations -DeviceConfigurationId $deviceConfigurationAssignments[0].deviceConfigurationId
-            }
+                $deviceConfigurationObject = Invoke-MgGraphRequest -Uri "$apiVersion/deviceManagement/deviceConfigurations/$($deviceConfigurationAssignment.sourceid)" | Get-MGGraphAllPages
+            }   
             else {
-                $deviceConfigurationObject = Get-DeviceManagement_DeviceConfigurations | Get-MSGraphAllPages | Where-Object displayName -eq "$($deviceConfiguration.BaseName)"
+                $deviceConfigurationObject = Invoke-MgGraphRequest -Uri "$apiVersion/deviceManagement/deviceConfigurations" | Get-MGGraphAllPages | Where-Object displayName -eq $deviceConfigurationName
                 if (-not ($deviceConfigurationObject)) {
                     Write-Verbose "Error retrieving Intune Device Configuration for $($deviceConfiguration.FullName). Skipping assignment restore" -Verbose
                     continue
@@ -79,7 +84,7 @@ function Invoke-IntuneRestoreDeviceConfigurationAssignment {
 
         # Restore the assignments
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Content $requestBody.toString() -Url "deviceManagement/deviceConfigurations/$($deviceConfigurationObject.id)/assign" -ErrorAction Stop
+            $null = Invoke-MgGraphRequest -Method POST -body $requestBody.toString() -Uri "$apiVersion/deviceManagement/deviceConfigurations/$($deviceConfigurationObject.id)/assign" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Configuration Assignments"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
@@ -21,25 +21,51 @@ function Invoke-IntuneRestoreDeviceManagementIntent {
         [Parameter(Mandatory = $false)]
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
+
     )
 
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }
+
     # Set the Microsoft Graph API endpoint
-    if (-not ((Get-MSGraphEnvironment).SchemaVersion -eq $apiVersion)) {
-        Update-MSGraphEnvironment -SchemaVersion $apiVersion -Quiet
-        Connect-MSGraph -ForceNonInteractive -Quiet
+    if (-not ((Get-MgProfile).name -eq $apiVersion)) {
+        Select-MgProfile -Name "beta"
     }
 
     # Get all device management intents
     $deviceManagementIntents = Get-ChildItem -Path "$Path\Device Management Intents" -Recurse -File
+
+    #Used to exclude Onboarding/Offboarding blob settings if AutoPopulateOnboardingBlob is set to $true
+    $excludedEDRDefinitions = @(
+        "deviceConfiguration--windowsDefenderAdvancedThreatProtectionConfiguration_advancedThreatProtectionBlobType"
+        "deviceConfiguration--windowsDefenderAdvancedThreatProtectionConfiguration_advancedThreatProtectionOffboardingBlob"
+        "deviceConfiguration--windowsDefenderAdvancedThreatProtectionConfiguration_advancedThreatProtectionOnboardingBlob"
+        "deviceConfiguration--windowsDefenderAdvancedThreatProtectionConfiguration_advancedThreatProtectionOnboardingFilename"
+        "deviceConfiguration--windowsDefenderAdvancedThreatProtectionConfiguration_advancedThreatProtectionOffboardingFilename"
+    )
+
     foreach ($deviceManagementIntent in $deviceManagementIntents) {
-        $deviceManagementIntentContent = Get-Content -LiteralPath $deviceManagementIntent.FullName -Raw
-        $deviceManagementIntentDisplayName = ($deviceManagementIntentContent | ConvertFrom-Json).displayName
+        if($deviceManagementIntent.DirectoryName -match "Assignments"){continue}
+        $deviceManagementIntentContent = Get-Content -LiteralPath $deviceManagementIntent.FullName | ConvertFrom-Json
         $templateId = $deviceManagementIntent.Name.Split("_")[0]
         $templateDisplayName = ($deviceManagementIntent).DirectoryName.Split('\')[-1]
 
+        $deviceManagementIntentDisplayName = $deviceManagementIntentContent.displayName
+
+        #When importing an EDR policy, if AutoPopulateOnboardingBlob is set to true, the onboarding blob policies need to be set to null or removed.
+        If ($templateId -eq "e44c2ca3-2f9a-400a-a113-6cc88efd773d") {
+            $AutoPopulateOnboardingBlob = ($deviceManagementIntentContent.settingsDelta | ? { $_.definitionId -eq "deviceConfiguration--windowsDefenderAdvancedThreatProtectionConfiguration_advancedThreatProtectionAutoPopulateOnboardingBlob" }).value
+            If ($AutoPopulateOnboardingBlob) {
+                $deviceManagementIntentContent.settingsDelta = $deviceManagementIntentContent.settingsDelta | ? { $excludedEDRDefinitions -notcontains $_.definitionId }
+            }
+        }
+        
+        $deviceManagementIntentJson = $($deviceManagementIntentContent | convertto-json -Depth 100)
         # Restore the device management intent
         try {
-            $null = Invoke-MSGraphRequest -HttpMethod POST -Url "deviceManagement/templates/$($templateId)/createInstance" -Content $deviceManagementIntentContent.toString() -ErrorAction Stop
+            New-MgDeviceManagementTemplateInstance -DeviceManagementTemplateId $templateId -BodyParameter $deviceManagementIntentJson
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Management Intent"

--- a/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
@@ -15,7 +15,7 @@ function Start-IntuneBackup() {
     .NOTES
     Requires the MSGraphFunctions PowerShell Module
 
-    Connect to MSGraph first, using the 'Connect-Graph' cmdlet.
+    Connect to MSGraph first, using the 'connect-mggraph' cmdlet and the scopes: 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All'.
     #>
 
     [CmdletBinding()]
@@ -29,6 +29,26 @@ function Start-IntuneBackup() {
         "Type"   = "Intune Backup and Restore Action"
         "Name"   = "IntuneBackupAndRestore - Start Intune Backup Config and Assignments"
         "Path"   = $Path
+    }
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "EntitlementManagement.ReadWrite.All, DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }else{
+        Write-Host "MS-Graph already connected, checking scopes"
+        $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
+        $IncorrectScopes = $false
+        if ($scopes -notcontains "DeviceManagementApps.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementConfiguration.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementServiceConfig.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementManagedDevices.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($IncorrectScopes) {
+            Write-Host "Incorrect scopes, please sign in again"
+            connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
+        }else{
+            Write-Host "MS-Graph scopes are correct"     
+        }
+  
     }
 
     Invoke-IntuneBackupClientApp -Path $Path

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreAssignments.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreAssignments.ps1
@@ -36,6 +36,26 @@ function Start-IntuneRestoreAssignments() {
         "Path"   = $Path
     }
 
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "EntitlementManagement.ReadWrite.All, DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }else{
+        Write-Host "MS-Graph already connected, checking scopes"
+        $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
+        $IncorrectScopes = $false
+        if ($scopes -notcontains "DeviceManagementApps.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementConfiguration.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementServiceConfig.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementManagedDevices.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($IncorrectScopes) {
+            Write-Host "Incorrect scopes, please sign in again"
+            connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
+        }else{
+            Write-Host "MS-Graph scopes are correct"     
+        }
+  
+    }
+
     Invoke-IntuneRestoreConfigurationPolicyAssignment -Path $path -RestoreById $restoreById
     Invoke-IntuneRestoreClientAppAssignment -Path $path -RestoreById $restoreById
     Invoke-IntuneRestoreDeviceCompliancePolicyAssignment -Path $path -RestoreById $restoreById

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
@@ -31,6 +31,26 @@ function Start-IntuneRestoreConfig() {
         "Path"   = $Path
     }
 
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "EntitlementManagement.ReadWrite.All, DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    }else{
+        Write-Host "MS-Graph already connected, checking scopes"
+        $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
+        $IncorrectScopes = $false
+        if ($scopes -notcontains "DeviceManagementApps.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementConfiguration.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementServiceConfig.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($scopes -notcontains "DeviceManagementManagedDevices.ReadWrite.All") {$IncorrectScopes = $true}
+        if ($IncorrectScopes) {
+            Write-Host "Incorrect scopes, please sign in again"
+            connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
+        }else{
+            Write-Host "MS-Graph scopes are correct"     
+        }
+  
+    }
+
     Invoke-IntuneRestoreConfigurationPolicy -Path $Path
     Invoke-IntuneRestoreDeviceCompliancePolicy -Path $Path
     Invoke-IntuneRestoreDeviceConfiguration -Path $Path

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Update-Module -Name IntuneBackupAndRestore
 ```
 
 ## Prerequisites
-As of version 2.0.0, the IntuneBackupAndRestore PowerShell Module has migrated from the MSGraphFunctions PowerShell module to the Microsoft.Graph.Intune PowerShell module. Please make sure you meet the prerequisites below.
-
 - Requires [Microsoft.Graph](https://github.com/microsoftgraph/msgraph-sdk-powershell) PowerShell Module (`Install-Module -Name Microsoft.Graph`)
 - Make sure to import the IntuneBackupAndRestore PowerShell module before using it with the `Import-Module IntuneBackupAndRestore` cmdlet.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Conversion of [Jseerden's excellent IntuneBackupAndRestore module](https://github.com/jseerden/IntuneBackupAndRestore) from [Microsoft.Graph.Intune](https://github.com/microsoft/Intune-PowerShell-SDK) to [Microsoft.Graph](https://github.com/microsoftgraph/msgraph-sdk-powershell). This is required as the Microsoft.Graph.Intune module used ADAL authentication which will be EOL June 2023.
-
 # Intune Backup & Restore
 
 ![PowerShell Gallery](https://img.shields.io/powershellgallery/v/IntuneBackupAndRestore.svg?label=PSGallery%20Version&logo=PowerShell&style=flat-square)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Conversion of [Jseerden's excellent IntuneBackupAndRestore module](https://github.com/jseerden/IntuneBackupAndRestore) from [Microsoft.Graph.Intune](https://github.com/microsoft/Intune-PowerShell-SDK) to [Microsoft.Graph](https://github.com/microsoftgraph/msgraph-sdk-powershell). This is required as the Microsoft.Graph.Intune module used ADAL authentication which will be EOL June 2023.
+
 # Intune Backup & Restore
 
 ![PowerShell Gallery](https://img.shields.io/powershellgallery/v/IntuneBackupAndRestore.svg?label=PSGallery%20Version&logo=PowerShell&style=flat-square)
@@ -25,8 +27,7 @@ Update-Module -Name IntuneBackupAndRestore
 ## Prerequisites
 As of version 2.0.0, the IntuneBackupAndRestore PowerShell Module has migrated from the MSGraphFunctions PowerShell module to the Microsoft.Graph.Intune PowerShell module. Please make sure you meet the prerequisites below.
 
-- Requires [Microsoft.Graph.Intune](https://github.com/Microsoft/Intune-PowerShell-SDK/) PowerShell Module (`Install-Module -Name Microsoft.Graph.Intune`)
-- Connect to Microsoft Graph using the `Connect-MSGraph` PSCmdlet first.
+- Requires [Microsoft.Graph](https://github.com/microsoftgraph/msgraph-sdk-powershell) PowerShell Module (`Install-Module -Name Microsoft.Graph`)
 - Make sure to import the IntuneBackupAndRestore PowerShell module before using it with the `Import-Module IntuneBackupAndRestore` cmdlet.
 
 ## Features


### PR DESCRIPTION
Given that all thing M365 Powershell is being pushed into the Microsoft.Graph module, I thought it would be a good time to convert this module. 

The current module relies on the all but dead [Microsoft.Graph.Intune](https://github.com/Microsoft/Intune-PowerShell-SDK/) module. Its current implementation of connect-msgraph uses the ADAL endpoint which will be[ EOL June 2023](https://learn.microsoft.com/en-au/azure/active-directory/fundamentals/whats-new#adal-end-of-support-announcement), which means this module will likely cease to work after the current date

This conversion brings the following:
- Authentication via the Microsoft.Graph module (MSAL)
- Powershell 7 support
- Backups generated with the MSGraph version are still compatible

I've tried to keep the original style as much as possible, however, due to a few bits of fun with the graph API I have had to change a few things.

_This is the first project I've committed code to, please let me know if I've messed anything up_

