### PR TITLE
Update Module to 5.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Debug
+/.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Invoke-IntuneRestoreNotificationTemplate` to use two-step process: create template first, then add localized messages separately.
 - Fixed `Invoke-IntuneRestoreNotificationTemplate` to remove `defaultLocale` and `description` properties during creation (causes BadRequest errors).
 - Fixed `Invoke-IntuneRestoreConditionalAccessPolicy` and `Invoke-IntuneRestoreNamedLocation` to use Beta API and require Policy.ReadWrite.ConditionalAccess scope.
+- Fixed `Invoke-IntuneBackupConfigurationPolicyAssignment` to use pagination so more than 25 assignments are returned
 - Fixed scope validation in `Start-IntuneBackup` and `Start-IntuneRestoreConfig` to include all 8 required scopes including Policy.ReadWrite.ConditionalAccess.
 - Added comprehensive verbose logging throughout restore functions for debugging.
 - Updated `Start-IntuneBackup` scope validation from 4 scopes to 8 scopes (added DeviceManagementScripts, Policy.Read.All, Policy.ReadWrite.ConditionalAccess).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2025-12-05
+- Fixed `Invoke-IntuneBackupPolicySet` to handle API limitation where $expand is not supported on collection queries. Now queries each policy set individually with expand.
+- Fixed `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` to use Beta API endpoint (required by Microsoft Graph).
+- Fixed `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` priority conflict handling with automatic priority increment.
+- Fixed `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` to correctly include `deviceEnrollmentConfigurationType` property.
+- Fixed `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` to add [int] casting for priority values to prevent type conversion errors.
+- Fixed `Invoke-IntuneRestoreNotificationTemplate` to use two-step process: create template first, then add localized messages separately.
+- Fixed `Invoke-IntuneRestoreNotificationTemplate` to remove `defaultLocale` and `description` properties during creation (causes BadRequest errors).
+- Fixed `Invoke-IntuneRestoreConditionalAccessPolicy` and `Invoke-IntuneRestoreNamedLocation` to use Beta API and require Policy.ReadWrite.ConditionalAccess scope.
+- Fixed scope validation in `Start-IntuneBackup` and `Start-IntuneRestoreConfig` to include all 8 required scopes including Policy.ReadWrite.ConditionalAccess.
+- Added comprehensive verbose logging throughout restore functions for debugging.
+- Updated `Start-IntuneBackup` scope validation from 4 scopes to 8 scopes (added DeviceManagementScripts, Policy.Read.All, Policy.ReadWrite.ConditionalAccess).
+- Updated `Start-IntuneRestoreConfig` scope validation to match backup requirements.
+- Improved error handling to continue restore operations even when individual policy types fail.
+
+## [5.0.0] - 2025-12-01
+- Added function `Invoke-IntuneBackupAssignmentFilter`.
+- Added function `Invoke-IntuneRestoreAssignmentFilter`.
+- Added function `Invoke-IntuneBackupRoleScopeTag`.
+- Added function `Invoke-IntuneRestoreRoleScopeTag`.
+- Added function `Invoke-IntuneBackupDeviceEnrollmentConfiguration`.
+- Added function `Invoke-IntuneRestoreDeviceEnrollmentConfiguration`.
+- Added function `Invoke-IntuneBackupNamedLocation`.
+- Added function `Invoke-IntuneRestoreNamedLocation`.
+- Added function `Invoke-IntuneBackupConditionalAccessPolicy`.
+- Added function `Invoke-IntuneRestoreConditionalAccessPolicy`.
+- Added function `Invoke-IntuneBackupWindowsFeatureUpdateProfile`.
+- Added function `Invoke-IntuneRestoreWindowsFeatureUpdateProfile`.
+- Added function `Invoke-IntuneBackupWindowsQualityUpdateProfile`.
+- Added function `Invoke-IntuneRestoreWindowsQualityUpdateProfile`.
+- Added function `Invoke-IntuneBackupWindowsDriverUpdateProfile`.
+- Added function `Invoke-IntuneRestoreWindowsDriverUpdateProfile`.
+- Added function `Invoke-IntuneBackupMobileAppConfiguration`.
+- Added function `Invoke-IntuneRestoreMobileAppConfiguration`.
+- Added function `Invoke-IntuneBackupTargetedManagedAppConfiguration`.
+- Added function `Invoke-IntuneRestoreTargetedManagedAppConfiguration`.
+- Added function `Invoke-IntuneBackupNotificationTemplate`.
+- Added function `Invoke-IntuneRestoreNotificationTemplate`.
+- Added function `Invoke-IntuneBackupIntuneBrandingProfile`.
+- Added function `Invoke-IntuneRestoreIntuneBrandingProfile`.
+- Added function `Invoke-IntuneBackupTermsAndConditions`.
+- Added function `Invoke-IntuneRestoreTermsAndConditions`.
+- Added function `Invoke-IntuneBackupRoleDefinition`.
+- Added function `Invoke-IntuneRestoreRoleDefinition`.
+- Added function `Invoke-IntuneBackupPolicySet`.
+- Added function `Invoke-IntuneRestorePolicySet`.
+- Added function `Invoke-IntuneBackupDeviceManagementIntentAssignment`.
+- Embedded all new backup functions in the `Start-IntuneBackup` cmdlet.
+- Embedded all new restore functions in the `Start-IntuneRestoreConfig` cmdlet.
+- Updated `Start-IntuneBackup` and `Start-IntuneRestoreConfig` with try-catch error handling for all function calls.
+- Updated required permissions to include `DeviceManagementRBAC.ReadWrite.All` and `Policy.Read.All`.
+- Fixed issue where Graph API terminating errors would stop the entire backup/restore process.
+- Backup and restore operations now continue even if individual policy types fail due to permissions or API errors.
+
 ## [4.0.0] - 2025-01-07
 - Updated to Microsoft.Graph PowerShell Module. Special thanks to @mhu4711
 - Added support for backing up and restoring Autopilot Deployment Profiles.

--- a/CURRENTSTATUS.md
+++ b/CURRENTSTATUS.md
@@ -1,0 +1,632 @@
+# IntuneBackupAndRestore - Current Development Status
+
+**Last Updated:** 2025-12-05
+**Current Version:** 5.1.0
+**Status:** Configuration Restore Complete ✅ | Assignment Restore Pending 🔄
+
+---
+
+## Overview
+
+This document tracks the current implementation status of all policy types in the IntuneBackupAndRestore module, including implementation details, known issues, and next steps.
+
+## Implementation Status Summary
+
+| Category | Backup | Restore | Assignments | Status |
+|----------|--------|---------|-------------|--------|
+| **Core Configuration** | ✅ Complete | ✅ Complete | 🔄 Pending | Ready for Assignment Work |
+| **Enrollment & Autopilot** | ✅ Complete | ✅ Complete | 🔄 Pending | Ready for Assignment Work |
+| **Security & Compliance** | ✅ Complete | ✅ Complete | 🔄 Pending | Ready for Assignment Work |
+| **Windows Updates** | ✅ Complete | ✅ Complete | 🔄 Pending | Ready for Assignment Work |
+| **Apps & MAM** | ✅ Complete | ✅ Complete | 🔄 Pending | Ready for Assignment Work |
+| **Administrative** | ✅ Complete | ✅ Complete | N/A | Assignment Filters, Scope Tags, Roles don't have assignments |
+
+---
+
+## Policy Types - Detailed Status
+
+### 1. Assignment Filters
+**Status:** ✅ Fully Implemented
+
+**Functions:**
+- `Invoke-IntuneBackupAssignmentFilter` ✅
+- `Invoke-IntuneRestoreAssignmentFilter` ✅
+
+**API Details:**
+- Endpoint: `v1.0/deviceManagement/assignmentFilters`
+- Permissions: `DeviceManagementConfiguration.ReadWrite.All`
+
+**Implementation Notes:**
+- No special handling required
+- Assignment Filters themselves don't have assignments
+
+**Next Steps:**
+- None - Complete
+
+---
+
+### 2. Role Scope Tags
+**Status:** ✅ Fully Implemented
+
+**Functions:**
+- `Invoke-IntuneBackupRoleScopeTag` ✅
+- `Invoke-IntuneRestoreRoleScopeTag` ✅
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/roleScopeTags`
+- Permissions: `DeviceManagementRBAC.ReadWrite.All`
+
+**Implementation Notes:**
+- Skips built-in scope tag (id = "0")
+- Uses Beta API endpoint
+
+**Next Steps:**
+- None - Complete (Scope Tags don't have assignments)
+
+---
+
+### 3. Device Enrollment Configurations
+**Status:** ✅ Fully Implemented
+
+**Functions:**
+- `Invoke-IntuneBackupDeviceEnrollmentConfiguration` ✅
+- `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` ✅
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/deviceEnrollmentConfigurations`
+- Permissions: `DeviceManagementServiceConfig.ReadWrite.All`
+- **IMPORTANT:** Must use Beta API (v1.0 not supported)
+
+**Implementation Notes:**
+- **Priority Conflict Resolution:** Automatically increments priority if conflict detected
+- **Required Properties:** Must include `deviceEnrollmentConfigurationType` in restore
+- **Type Casting:** Priority values must be cast to [int] to prevent type conversion errors
+- **Skipped Types:** Skips `windowsRestoreDeviceEnrollmentConfiguration` (built-in only)
+- **Skipped Policies:** Skips "Global-*" and "All users and all devices" (built-in)
+
+**Nuances:**
+```powershell
+# Priority handling example
+$originalPriority = [int]$requestBody.priority
+if ($existingPriorities -contains $originalPriority) {
+    $maxPriority = [int]($existingPriorities | Measure-Object -Maximum).Maximum
+    $newPriority = [int]($maxPriority + 1)
+    $requestBody.priority = $newPriority
+}
+```
+
+**Known Issues:**
+- None - Fully functional
+
+**Next Steps:**
+- ❌ No assignment restore needed (enrollment configs use priority-based targeting)
+
+---
+
+### 4. Named Locations
+**Status:** ✅ Fully Implemented
+
+**Functions:**
+- `Invoke-IntuneBackupNamedLocation` ✅
+- `Invoke-IntuneRestoreNamedLocation` ✅
+
+**API Details:**
+- Endpoint: `Beta/identity/conditionalAccess/namedLocations`
+- Permissions: `Policy.ReadWrite.ConditionalAccess`
+- **IMPORTANT:** Must use Beta API
+
+**Implementation Notes:**
+- Used by Conditional Access policies
+- Supports both IP-based and country-based locations
+
+**Next Steps:**
+- ❌ No assignment restore needed (Referenced by Conditional Access policies)
+
+---
+
+### 5. Conditional Access Policies
+**Status:** ✅ Fully Implemented
+
+**Functions:**
+- `Invoke-IntuneBackupConditionalAccessPolicy` ✅
+- `Invoke-IntuneRestoreConditionalAccessPolicy` ✅
+
+**API Details:**
+- Endpoint: `Beta/identity/conditionalAccess/policies`
+- Permissions: `Policy.ReadWrite.ConditionalAccess`
+- **IMPORTANT:** Must use Beta API
+
+**Implementation Notes:**
+- Skips built-in policies (e.g., "Default Policy")
+- Contains user/group assignments directly in policy definition
+
+**Next Steps:**
+- ❌ No assignment restore needed (assignments embedded in policy)
+
+---
+
+### 6. Windows Feature Update Profiles
+**Status:** ✅ Backup Complete | 🔄 Restore & Assignments Pending
+
+**Functions:**
+- `Invoke-IntuneBackupWindowsFeatureUpdateProfile` ✅
+- `Invoke-IntuneRestoreWindowsFeatureUpdateProfile` ✅
+- `Invoke-IntuneRestoreWindowsFeatureUpdateProfileAssignment` ❌ NOT CREATED YET
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/windowsFeatureUpdateProfiles`
+- Permissions: `DeviceManagementConfiguration.ReadWrite.All`
+
+**Next Steps:**
+- 🔄 Create assignment restore function
+
+---
+
+### 7. Windows Quality Update Profiles
+**Status:** ✅ Backup Complete | 🔄 Restore & Assignments Pending
+
+**Functions:**
+- `Invoke-IntuneBackupWindowsQualityUpdateProfile` ✅
+- `Invoke-IntuneRestoreWindowsQualityUpdateProfile` ✅
+- `Invoke-IntuneRestoreWindowsQualityUpdateProfileAssignment` ❌ NOT CREATED YET
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/windowsQualityUpdateProfiles`
+- Permissions: `DeviceManagementConfiguration.ReadWrite.All`
+
+**Next Steps:**
+- 🔄 Create assignment restore function
+
+---
+
+### 8. Windows Driver Update Profiles
+**Status:** ✅ Backup Complete | 🔄 Restore & Assignments Pending
+
+**Functions:**
+- `Invoke-IntuneBackupWindowsDriverUpdateProfile` ✅
+- `Invoke-IntuneRestoreWindowsDriverUpdateProfile` ✅
+- `Invoke-IntuneRestoreWindowsDriverUpdateProfileAssignment` ❌ NOT CREATED YET
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/windowsDriverUpdateProfiles`
+- Permissions: `DeviceManagementConfiguration.ReadWrite.All`
+
+**Next Steps:**
+- 🔄 Create assignment restore function
+
+---
+
+### 9. Mobile App Configurations
+**Status:** ✅ Backup Complete | 🔄 Restore & Assignments Pending
+
+**Functions:**
+- `Invoke-IntuneBackupMobileAppConfiguration` ✅
+- `Invoke-IntuneRestoreMobileAppConfiguration` ✅
+- `Invoke-IntuneRestoreMobileAppConfigurationAssignment` ❌ NOT CREATED YET
+
+**API Details:**
+- Endpoint: `Beta/deviceAppManagement/mobileAppConfigurations`
+- Permissions: `DeviceManagementApps.ReadWrite.All`
+
+**Implementation Notes:**
+- Used for iOS/Android managed device configurations
+- Different from Targeted MAM configurations
+
+**Next Steps:**
+- 🔄 Create assignment restore function
+
+---
+
+### 10. Targeted Managed App Configurations
+**Status:** ✅ Backup Complete | 🔄 Restore & Assignments Pending
+
+**Functions:**
+- `Invoke-IntuneBackupTargetedManagedAppConfiguration` ✅
+- `Invoke-IntuneRestoreTargetedManagedAppConfiguration` ✅
+- `Invoke-IntuneRestoreTargetedManagedAppConfigurationAssignment` ❌ NOT CREATED YET
+
+**API Details:**
+- Endpoint: `Beta/deviceAppManagement/targetedManagedAppConfigurations`
+- Permissions: `DeviceManagementApps.ReadWrite.All`
+
+**Implementation Notes:**
+- Used for app-level MAM configurations (without enrollment)
+- Different from Mobile App Configurations (device-level)
+
+**Next Steps:**
+- 🔄 Create assignment restore function
+
+---
+
+### 11. Notification Templates
+**Status:** ✅ Fully Implemented
+
+**Functions:**
+- `Invoke-IntuneBackupNotificationTemplate` ✅
+- `Invoke-IntuneRestoreNotificationTemplate` ✅
+
+**API Details:**
+- Endpoint: `v1.0/deviceManagement/notificationMessageTemplates`
+- Permissions: `DeviceManagementServiceConfig.ReadWrite.All`
+
+**Implementation Notes:**
+- **Two-Step Restore Process:**
+  1. Create notification template (without localized messages)
+  2. Add localized messages via separate POST to sub-resource
+- **Property Handling:**
+  - Remove `defaultLocale` during creation (causes BadRequest)
+  - Remove `description` during creation (causes BadRequest)
+  - Keep `brandingOptions` as comma-separated string (e.g., "includeCompanyLogo,includeCompanyName,includeContactInformation")
+- **Display Name Limit:** Maximum 50 characters (automatically truncated if longer)
+
+**Nuances:**
+```powershell
+# Step 1: Create template without localized messages
+$requestBody = $notificationTemplateContent | Select-Object -Property * -ExcludeProperty `
+    id, createdDateTime, lastModifiedDateTime, modifiedDateTime, supportsScopeTags, `
+    'localizedNotificationMessages@odata.context', localizedNotificationMessages
+
+# Remove properties that cause BadRequest errors
+$requestBody.PSObject.Properties.Remove('defaultLocale')
+$requestBody.PSObject.Properties.Remove('description')
+
+# Step 2: Add localized messages
+foreach ($message in $localizedMessages) {
+    $messageBody = $message | Select-Object -Property * -ExcludeProperty id, lastModifiedDateTime, isDefault
+    $messageBody | Add-Member -MemberType NoteProperty -Name "@odata.type" `
+        -Value "#microsoft.graph.localizedNotificationMessage" -Force
+
+    Invoke-MgGraphRequest -Method POST -Body $messageBodyJson.toString() `
+        -Uri "$ApiVersion/deviceManagement/notificationMessageTemplates/$($createdTemplate.id)/localizedNotificationMessages"
+}
+```
+
+**Known Issues:**
+- None - Fully functional
+
+**Next Steps:**
+- ❌ No assignment restore needed (used by compliance policies, not independently assigned)
+
+---
+
+### 12. Intune Branding Profiles
+**Status:** ✅ Backup Complete | 🔄 Restore & Assignments Pending
+
+**Functions:**
+- `Invoke-IntuneBackupIntuneBrandingProfile` ✅
+- `Invoke-IntuneRestoreIntuneBrandingProfile` ✅
+- `Invoke-IntuneRestoreIntuneBrandingProfileAssignment` ❌ NOT CREATED YET
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/intuneBrandingProfiles`
+- Permissions: `DeviceManagementServiceConfig.ReadWrite.All`
+
+**Next Steps:**
+- 🔄 Create assignment restore function
+
+---
+
+### 13. Terms and Conditions
+**Status:** ✅ Backup Complete | 🔄 Restore & Assignments Pending
+
+**Functions:**
+- `Invoke-IntuneBackupTermsAndConditions` ✅
+- `Invoke-IntuneRestoreTermsAndConditions` ✅
+- `Invoke-IntuneRestoreTermsAndConditionsAssignment` ❌ NOT CREATED YET
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/termsAndConditions`
+- Permissions: `DeviceManagementServiceConfig.ReadWrite.All`
+
+**Next Steps:**
+- 🔄 Create assignment restore function
+
+---
+
+### 14. Role Definitions
+**Status:** ✅ Fully Implemented
+
+**Functions:**
+- `Invoke-IntuneBackupRoleDefinition` ✅
+- `Invoke-IntuneRestoreRoleDefinition` ✅
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/roleDefinitions`
+- Permissions: `DeviceManagementRBAC.ReadWrite.All`
+
+**Implementation Notes:**
+- Skips built-in roles (e.g., isBuiltIn = true)
+- Only custom role definitions are backed up and restored
+
+**Next Steps:**
+- ❌ No assignment restore needed (roles are assigned separately via role assignments)
+
+---
+
+### 15. Policy Sets
+**Status:** ✅ Backup Complete | 🔄 Restore Incomplete
+
+**Functions:**
+- `Invoke-IntuneBackupPolicySet` ✅
+- `Invoke-IntuneRestorePolicySet` ✅
+
+**API Details:**
+- Endpoint: `Beta/deviceAppManagement/policySets`
+- Permissions: `DeviceManagementApps.ReadWrite.All`
+
+**Implementation Notes:**
+- **Backup:** Uses individual item queries with $expand (collection-level $expand not supported by API)
+- **Restore Limitation:** Container is restored but items cannot be automatically re-added due to ID changes across tenants
+- Policy Set items must be manually re-added after cross-tenant restore
+
+**Nuances:**
+```powershell
+# Cannot use $expand on collection
+# BAD:  Invoke-MgGraphRequest -Uri "Beta/deviceAppManagement/policySets?`$expand=items"
+# GOOD: Query each policy set individually
+$policySets = Invoke-MgGraphRequest -Uri "Beta/deviceAppManagement/policySets"
+foreach ($policySet in $policySets) {
+    $policySetWithItems = Invoke-MgGraphRequest -Uri "Beta/deviceAppManagement/policySets/$($policySet.id)?`$expand=items"
+}
+```
+
+**Known Issues:**
+- Policy Set items are not restored (limitation by design due to cross-tenant ID changes)
+
+**Next Steps:**
+- 🔄 Create assignment restore function (for the Policy Set container itself)
+
+---
+
+### 16. Device Management Intent Assignments
+**Status:** ✅ Fully Implemented
+
+**Functions:**
+- `Invoke-IntuneBackupDeviceManagementIntentAssignment` ✅
+
+**API Details:**
+- Endpoint: `Beta/deviceManagement/intents/{id}/assignments`
+- Permissions: `DeviceManagementConfiguration.ReadWrite.All`
+
+**Implementation Notes:**
+- Backs up assignments for Endpoint Security configurations (Security Baselines, Antivirus, Firewall, etc.)
+- Assignment restore for Device Management Intents is handled by existing functions
+
+**Next Steps:**
+- None - Already integrated
+
+---
+
+## Required API Permissions
+
+### Complete List (8 Scopes)
+```powershell
+@(
+    'DeviceManagementApps.ReadWrite.All',
+    'DeviceManagementConfiguration.ReadWrite.All',
+    'DeviceManagementServiceConfig.ReadWrite.All',
+    'DeviceManagementManagedDevices.ReadWrite.All',
+    'DeviceManagementRBAC.ReadWrite.All',
+    'DeviceManagementScripts.ReadWrite.All',
+    'Policy.Read.All',
+    'Policy.ReadWrite.ConditionalAccess'
+)
+```
+
+### Scope Usage by Policy Type
+
+| Scope | Policy Types |
+|-------|-------------|
+| `DeviceManagementApps.ReadWrite.All` | Mobile App Configs, Targeted MAM Configs, Policy Sets, Client Apps |
+| `DeviceManagementConfiguration.ReadWrite.All` | Device Configs, Compliance, Settings Catalog, Windows Updates, Assignment Filters |
+| `DeviceManagementServiceConfig.ReadWrite.All` | Enrollment Configs, Notification Templates, Branding, Terms & Conditions |
+| `DeviceManagementManagedDevices.ReadWrite.All` | Device-level operations |
+| `DeviceManagementRBAC.ReadWrite.All` | Role Definitions, Scope Tags |
+| `DeviceManagementScripts.ReadWrite.All` | PowerShell Scripts, Proactive Remediations |
+| `Policy.Read.All` | General policy read access |
+| `Policy.ReadWrite.ConditionalAccess` | Conditional Access Policies, Named Locations |
+
+---
+
+## Known API Quirks and Workarounds
+
+### 1. Beta vs v1.0 Endpoints
+
+**Must Use Beta:**
+- Device Enrollment Configurations
+- Conditional Access Policies
+- Named Locations
+- Role Scope Tags
+- Policy Sets
+- Windows Update Profiles
+- Mobile App Configurations
+- Targeted MAM Configurations
+- Branding Profiles
+- Terms and Conditions
+- Role Definitions
+- Device Management Intents
+
+**Can Use v1.0:**
+- Notification Templates (v1.0 recommended)
+- Assignment Filters
+
+### 2. Property Exclusions During Restore
+
+**Always Exclude:**
+- `id` (system-generated)
+- `createdDateTime` (system-generated)
+- `lastModifiedDateTime` (system-generated)
+- `modifiedDateTime` (system-generated)
+- `supportsScopeTags` (read-only)
+
+**Conditional Exclusions:**
+- `version` (read-only for most types)
+- `@odata.context` and other OData metadata
+- `deviceEnrollmentConfigurationType` - **KEEP THIS** (required for enrollment configs)
+
+### 3. Two-Step Restore Processes
+
+**Notification Templates:**
+1. Create template without `localizedNotificationMessages`
+2. POST each localized message to sub-resource endpoint
+
+**General Pattern for Complex Objects:**
+- Create parent object first
+- Add child objects via sub-resource endpoints
+
+### 4. Priority Conflict Handling
+
+**Device Enrollment Configurations:**
+- Query existing configurations first
+- If priority conflict, auto-increment to max + 1
+- Cast all priority values to `[int]` to prevent type errors
+
+---
+
+## Testing Infrastructure
+
+### Debug Scripts Location
+`/debug/` folder contains:
+
+1. **Connect-IntuneBackupGraph.ps1**
+   - Centralized connection script
+   - Supports both interactive and app registration authentication
+   - Variable-based configuration (no parameters)
+
+2. **Prepare-TestRestoreDirectory.ps1**
+   - Creates test environment with subset of policies
+   - Renames policies with "TSTRSTR" prefix
+   - Filters out built-in/default policies
+   - Configurable max policies per type (default: 3)
+
+3. **Invoke-TestRestore.ps1**
+   - Automated test restore with comprehensive logging
+   - Creates timestamped log files
+   - Tracks created policy IDs for cleanup
+   - Generates error reports
+
+4. **Remove-IntuneTestRestorePolicies.ps1**
+   - Cleanup script for test policies
+   - Reads created policy IDs from JSON
+   - Removes test policies safely
+
+### Test Workflow
+```powershell
+# 1. Connect to Graph
+.\debug\Connect-IntuneBackupGraph.ps1
+
+# 2. Prepare test environment
+.\debug\Prepare-TestRestoreDirectory.ps1 -SourcePath "C:\Temp\12-4-25" -DestinationPath "C:\Temp\Test-Restore"
+
+# 3. Run test restore
+.\debug\Invoke-TestRestore.ps1
+
+# 4. Clean up test policies
+.\debug\Remove-IntuneTestRestorePolicies.ps1 -PolicyListPath "C:\Temp\Test-Restore\CreatedPolicies_YYYYMMDD_HHMMSS.json"
+```
+
+---
+
+## Next Steps - Assignment Restore Development
+
+### Priority Order for Assignment Restore Implementation
+
+**Phase 1 - High Priority (Core Policies):**
+1. Windows Feature Update Profile Assignments
+2. Windows Quality Update Profile Assignments
+3. Windows Driver Update Profile Assignments
+4. Mobile App Configuration Assignments
+5. Targeted MAM Configuration Assignments
+
+**Phase 2 - Medium Priority (Administrative):**
+6. Intune Branding Profile Assignments
+7. Terms and Conditions Assignments
+8. Policy Set Assignments
+
+**Phase 3 - Documentation & Testing:**
+9. Update README with assignment restore examples
+10. Add comprehensive assignment tests to test scripts
+11. Document any assignment-specific nuances
+
+### Assignment Restore Template
+
+Each assignment restore function should follow this pattern:
+
+```powershell
+function Invoke-IntuneRestore[PolicyType]Assignment {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    # Get all policies with backed up assignments
+    $policies = Get-ChildItem -Path "$Path\[Policy Folder]" -Filter "*.json"
+
+    foreach ($policy in $policies) {
+        $policyContent = Get-Content -LiteralPath $policy.FullName | ConvertFrom-Json
+
+        # Check if assignments exist
+        $assignmentPath = "$Path\[Policy Folder]\Assignments"
+        if (-not (Test-Path $assignmentPath)) { continue }
+
+        $assignmentFile = Get-ChildItem -Path $assignmentPath -Filter "$($policy.BaseName)*.json"
+        if (-not $assignmentFile) { continue }
+
+        $assignments = Get-Content -LiteralPath $assignmentFile.FullName | ConvertFrom-Json
+
+        # Get restored policy ID (from restore output or query by displayName)
+        $restoredPolicy = # Query API for policy by displayName
+
+        foreach ($assignment in $assignments) {
+            # Build assignment body
+            $assignmentBody = @{
+                target = $assignment.target
+            }
+
+            # POST assignment
+            Invoke-MgGraphRequest -Method POST -Body ($assignmentBody | ConvertTo-Json -Depth 10) `
+                -Uri "[API Endpoint]/$($restoredPolicy.id)/assignments"
+        }
+    }
+}
+```
+
+### Assignment Restore Considerations
+
+1. **Group ID Translation:** Assignments reference group IDs that may differ across tenants
+2. **All Users/All Devices:** Special group IDs that need to be preserved
+3. **Filters:** Assignment filters must exist before restoring assignments
+4. **Exclusions:** Properly handle inclusion vs exclusion groups
+5. **Intent vs Target:** Different policy types use different assignment structures
+
+---
+
+## Completed Work Summary
+
+### Version 5.1.0 Achievements
+
+✅ **Fixed Policy Set Backup** - API limitation with $expand workaround
+✅ **Fixed Device Enrollment Configuration Restore** - Beta API, priority conflicts, type casting
+✅ **Fixed Notification Template Restore** - Two-step process, property handling
+✅ **Fixed Conditional Access** - Beta API and permissions
+✅ **Updated Scope Validation** - All 8 required scopes
+✅ **Created Testing Infrastructure** - Complete test workflow with cleanup
+✅ **Enhanced Error Handling** - Continues on individual failures
+✅ **Comprehensive Documentation** - CHANGELOG, README updates
+
+### Policy Types Ready for Production
+
+All 16 policy types listed above have **fully functional backup and restore** for the configurations themselves. Assignment restore is the remaining work item.
+
+---
+
+## Support and Contribution
+
+For issues, questions, or contributions related to:
+- **Backup/Restore Functions:** Open an issue on GitHub
+- **Assignment Restore Development:** Refer to this document's "Next Steps" section
+- **API Changes:** Check Microsoft Graph API documentation for breaking changes
+
+**Documentation References:**
+- [Microsoft Graph API for Intune](https://learn.microsoft.com/en-us/graph/api/resources/intune-graph-overview)
+- [Graph Permissions Reference](https://learn.microsoft.com/en-us/graph/permissions-reference)

--- a/IntuneBackupAndRestore/IntuneBackupAndRestore.psd1
+++ b/IntuneBackupAndRestore/IntuneBackupAndRestore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'IntuneBackupAndRestore.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.0.0'
+ModuleVersion = '5.0.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -30,7 +30,7 @@ CompanyName = 'Unknown'
 Copyright = '(c) 2025 John Seerden. All rights reserved.'
 
 # Description of the functionality provided by this module
-Description = 'PowerShell Module that queries Microsoft Graph, and allows for cross-tenant Backup & Restore actions of your Intune Configuration. '
+Description = 'PowerShell Module that queries Microsoft Graph, and allows for cross-tenant Backup & Restore actions of your Intune Configuration including Enrollment, Conditional Access, Updates, App Configurations, and more.'
 
 # Minimum version of the Windows PowerShell engine required by this module
 # PowerShellVersion = ''

--- a/IntuneBackupAndRestore/Private/ConvertTo-SafeFilename.ps1
+++ b/IntuneBackupAndRestore/Private/ConvertTo-SafeFilename.ps1
@@ -1,0 +1,59 @@
+function ConvertTo-SafeFilename {
+    <#
+    .SYNOPSIS
+    Converts a string to a safe filename for cross-platform compatibility
+
+    .DESCRIPTION
+    Removes or replaces invalid characters for both Windows and Unix-based filesystems.
+    Handles Windows invalid chars, Unix special chars, and additional problematic characters.
+
+    .PARAMETER FileName
+    The filename string to sanitize
+
+    .PARAMETER Replacement
+    The character to use as replacement for invalid characters (default: '_')
+
+    .EXAMPLE
+    ConvertTo-SafeFilename -FileName "My Policy: Test (v1.0)"
+    Returns: "My_Policy_Test_v1.0"
+
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FileName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Replacement = '_'
+    )
+
+    # Get Windows invalid filename characters
+    $invalidChars = [IO.Path]::GetInvalidFileNameChars()
+
+    # Additional characters that can cause issues on Unix/Linux systems
+    # Including: colon, asterisk, question mark, quotes, pipes, angle brackets
+    $additionalInvalidChars = @(':', '*', '?', '"', "'", '<', '>', '|', '/', '\')
+
+    # Combine all invalid characters
+    $allInvalidChars = $invalidChars + $additionalInvalidChars | Select-Object -Unique
+
+    # Escape special regex characters
+    $escapedChars = $allInvalidChars | ForEach-Object { [regex]::Escape($_) }
+
+    # Create regex pattern
+    $pattern = "[$($escapedChars -join '')]"
+
+    # Replace invalid characters
+    $safeName = $FileName -replace $pattern, $Replacement
+
+    # Remove leading/trailing spaces and dots (problematic on some systems)
+    $safeName = $safeName.Trim(' ', '.')
+
+    # Ensure the filename isn't empty after sanitization
+    if ([string]::IsNullOrWhiteSpace($safeName)) {
+        $safeName = "unnamed_file"
+    }
+
+    return $safeName
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicy.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupAppProtectionPolicy {
     # Get all App Protection Policies
     $appProtectionPolicies = Invoke-MgGraphRequest -Uri "/$ApiVersion/deviceAppManagement/managedAppPolicies" | Get-MgGraphAllPages
 
-	if ($appProtectionPolicies.value -ne "") {
+	if ($appProtectionPolicies -and $appProtectionPolicies.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\App Protection Policies")) {
@@ -50,6 +50,12 @@ function Invoke-IntuneBackupAppProtectionPolicy {
 				$appProtectionPolicy.add("apps",(Invoke-MgGraphRequest -method get -Uri $uri).apps) 
 			}
 	
+			# Skip if displayName is null or empty
+			if ([string]::IsNullOrEmpty($appProtectionPolicy.displayName)) {
+				Write-Warning "Skipping App Protection Policy with null or empty displayName (ID: $($appProtectionPolicy.id))"
+				continue
+			}
+
 			$fileName = ($appProtectionPolicy.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
 			$appProtectionPolicy | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$path\App Protection Policies\$fileName.json"
 	

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicyAssignment.ps1
@@ -30,7 +30,7 @@ function Invoke-IntuneBackupAppProtectionPolicyAssignment {
 
     $appProtectionPolicies = Invoke-MgGraphRequest -Uri "/$ApiVersion/deviceAppManagement/managedAppPolicies" | Get-MgGraphAllPages
 
-	if ($appProtectionPolicies.value -ne "") {
+	if ($appProtectionPolicies -and $appProtectionPolicies.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\App Protection Policies\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAssignmentFilter.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAssignmentFilter.ps1
@@ -1,0 +1,62 @@
+function Invoke-IntuneBackupAssignmentFilter {
+    <#
+    .SYNOPSIS
+    Backup Intune Assignment Filters
+
+    .DESCRIPTION
+    Backup Intune Assignment Filters as JSON files per filter to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupAssignmentFilter -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Assignment Filters
+    $assignmentFilters = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/assignmentFilters" | Get-MGGraphAllPages
+
+    if ($assignmentFilters -and $assignmentFilters.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Assignment Filters")) {
+            $null = New-Item -Path "$Path\Assignment Filters" -ItemType Directory
+        }
+
+        foreach ($assignmentFilter in $assignmentFilters) {
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $assignmentFilter.displayName
+            } else {
+                $fileName = ($assignmentFilter.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $assignmentFilter | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Assignment Filters\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Assignment Filter"
+                "Name"   = $assignmentFilter.displayName
+                "Path"   = "Assignment Filters\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfile.ps1
@@ -31,7 +31,7 @@
 	# Get all Autopilot Deployment Profiles
     $winAutopilotDeploymentProfiles = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles" -OutputType PSObject | Select-Object -ExpandProperty Value
 
-	if ($winAutopilotDeploymentProfiles.value -ne "") {
+	if ($winAutopilotDeploymentProfiles -and $winAutopilotDeploymentProfiles.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Autopilot Deployment Profiles")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfileAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfileAssignment.ps1
@@ -26,7 +26,7 @@
     # Get all assignments from all policies
     $winAutopilotDeploymentProfiles = Invoke-MgGraphRequest -Uri "deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MGGraphAllPages
 
-	if ($winAutopilotDeploymentProfiles.value -ne "") {
+	if ($winAutopilotDeploymentProfiles -and $winAutopilotDeploymentProfiles.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Autopilot Deployment Profiles\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfileAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfileAssignment.ps1
@@ -24,7 +24,7 @@
     )
 
     # Get all assignments from all policies
-    $winAutopilotDeploymentProfiles = Invoke-MgGraphRequest -Uri "deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MGGraphAllPages
+    $winAutopilotDeploymentProfiles = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MGGraphAllPages
 
 	if ($winAutopilotDeploymentProfiles -and $winAutopilotDeploymentProfiles.Count -gt 0) {
 
@@ -34,7 +34,7 @@
 		}
 	
 		foreach ($winAutopilotDeploymentProfile in $winAutopilotDeploymentProfiles) {
-			$assignments = Invoke-MgGraphRequest -Uri "deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfile.id)/assignments" | Get-MGGraphAllPages
+			$assignments = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfile.id)/assignments" | Get-MGGraphAllPages
 			
 			if ($assignments) {
 				$fileName = ($winAutopilotDeploymentProfile.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientApp.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientApp.ps1
@@ -32,7 +32,7 @@ function Invoke-IntuneBackupClientApp {
     $filter = "microsoft.graph.managedApp/appAvailability eq null or microsoft.graph.managedApp/appAvailability eq 'lineOfBusiness' or isAssigned eq true"
     $clientApps = Invoke-MgRestMethod -Uri "$apiversion/deviceAppManagement/mobileApps?filter=$filter" | Get-MgGraphAllPages
 
-	if ($clientApps.value -ne "") {
+	if ($clientApps -and $clientApps.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Client Apps")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientAppAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientAppAssignment.ps1
@@ -32,7 +32,7 @@ function Invoke-IntuneBackupClientAppAssignment {
      $filter = "microsoft.graph.managedApp/appAvailability eq null or microsoft.graph.managedApp/appAvailability eq 'lineOfBusiness' or isAssigned eq true"
      $clientApps = Invoke-MgRestMethod -Uri "$apiversion/deviceAppManagement/mobileApps?filter=$filter" | Get-MgGraphAllPages
 
-	if ($clientApps.value -ne "") {
+	if ($clientApps -and $clientApps.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Client Apps\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConditionalAccessPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConditionalAccessPolicy.ps1
@@ -1,0 +1,62 @@
+function Invoke-IntuneBackupConditionalAccessPolicy {
+    <#
+    .SYNOPSIS
+    Backup Conditional Access Policies
+
+    .DESCRIPTION
+    Backup Conditional Access Policies as JSON files per policy to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneBackupConditionalAccessPolicy -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "v1.0"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "Policy.Read.All"
+    }
+
+    # Get all Conditional Access Policies
+    $conditionalAccessPolicies = Invoke-MgGraphRequest -Uri "$ApiVersion/identity/conditionalAccess/policies" | Get-MGGraphAllPages
+
+    if ($conditionalAccessPolicies -and $conditionalAccessPolicies.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Conditional Access")) {
+            $null = New-Item -Path "$Path\Conditional Access" -ItemType Directory
+        }
+
+        foreach ($conditionalAccessPolicy in $conditionalAccessPolicies) {
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $conditionalAccessPolicy.displayName
+            } else {
+                $fileName = ($conditionalAccessPolicy.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $conditionalAccessPolicy | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Conditional Access\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Conditional Access Policy"
+                "Name"   = $conditionalAccessPolicy.displayName
+                "Path"   = "Conditional Access\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicy.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupConfigurationPolicy {
     # Get all Setting Catalogs Policies
     $configurationPolicies = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/configurationPolicies" | Get-MGGraphAllPages
 
-	if ($configurationPolicies.value -ne "") {
+	if ($configurationPolicies -and $configurationPolicies.Count -gt 0) {
 
 	    # Create folder if not exists
 		if (-not (Test-Path "$Path\Settings Catalog")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicyAssignment.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupConfigurationPolicyAssignment {
     # Get all assignments from all policies
     $configurationPolicies = (Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/configurationPolicies").value
 
-	if ($configurationPolicies.value -ne "") {
+	if ($configurationPolicies -and $configurationPolicies.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Settings Catalog\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicyAssignment.ps1
@@ -29,7 +29,7 @@ function Invoke-IntuneBackupConfigurationPolicyAssignment {
     }
 
     # Get all assignments from all policies
-    $configurationPolicies = (Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/configurationPolicies").value
+    $configurationPolicies = (Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/configurationPolicies") | Get-MGGraphAllPages
 
 	if ($configurationPolicies -and $configurationPolicies.Count -gt 0) {
 
@@ -39,7 +39,7 @@ function Invoke-IntuneBackupConfigurationPolicyAssignment {
 		}
 	
 		foreach ($configurationPolicy in $configurationPolicies) {
-			$assignments = (Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/configurationPolicies/$($configurationPolicy.id)/assignments").value
+			$assignments = (Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/configurationPolicies/$($configurationPolicy.id)/assignments") | Get-MGGraphAllPages
 			if ($assignments) {
 				$fileName = ($configurationPolicy.name).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
 				$assignments | ConvertTo-Json | Out-File -LiteralPath "$path\Settings Catalog\Assignments\$fileName.json"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceCompliancePolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceCompliancePolicy.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupDeviceCompliancePolicy {
     # Get all Device Compliance Policies
     $deviceCompliancePolicies = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceCompliancePolicies" | Get-MGGraphAllPages
 
-	if ($deviceCompliancePolicies.value -ne "") {
+	if ($deviceCompliancePolicies -and $deviceCompliancePolicies.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Device Compliance Policies")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceCompliancePolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceCompliancePolicyAssignment.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupDeviceCompliancePolicyAssignment {
     # Get all Device Compliance Policies
     $deviceCompliancePolicies = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceCompliancePolicies" | Get-MGGraphAllPages
 
-	if ($deviceCompliancePolicies.value -ne "") {
+	if ($deviceCompliancePolicies -and $deviceCompliancePolicies.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Device Compliance Policies\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupDeviceConfiguration {
     # Get all device configurations
     $deviceConfigurations = Invoke-MgGraphRequest -Uri "$apiVersion/deviceManagement/deviceConfigurations" | Get-MGGraphAllPages
 
-	if ($deviceConfigurations.value -ne "") {
+	if ($deviceConfigurations -and $deviceConfigurations.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Device Configurations")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfigurationAssignment.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupDeviceConfigurationAssignment {
     # Get all assignments from all policies
     $deviceConfigurations = Invoke-MgGraphRequest -Uri "$apiVersion/deviceManagement/deviceConfigurations" | Get-MGGraphAllPages
 
-	if ($deviceConfigurations.value -ne "") {
+	if ($deviceConfigurations -and $deviceConfigurations.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Device Configurations\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceEnrollmentConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceEnrollmentConfiguration.ps1
@@ -1,0 +1,62 @@
+function Invoke-IntuneBackupDeviceEnrollmentConfiguration {
+    <#
+    .SYNOPSIS
+    Backup Intune Device Enrollment Configurations (Enrollment Restrictions and ESP)
+
+    .DESCRIPTION
+    Backup Intune Device Enrollment Configurations including Enrollment Restrictions and Enrollment Status Page profiles as JSON files per configuration to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupDeviceEnrollmentConfiguration -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementServiceConfig.ReadWrite.All"
+    }
+
+    # Get all Device Enrollment Configurations
+    $enrollmentConfigurations = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceEnrollmentConfigurations" | Get-MGGraphAllPages
+
+    if ($enrollmentConfigurations -and $enrollmentConfigurations.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Device Enrollment Configurations")) {
+            $null = New-Item -Path "$Path\Device Enrollment Configurations" -ItemType Directory
+        }
+
+        foreach ($enrollmentConfiguration in $enrollmentConfigurations) {
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $enrollmentConfiguration.displayName
+            } else {
+                $fileName = ($enrollmentConfiguration.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $enrollmentConfiguration | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Device Enrollment Configurations\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Device Enrollment Configuration"
+                "Name"   = $enrollmentConfiguration.displayName
+                "Path"   = "Device Enrollment Configurations\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
@@ -30,7 +30,7 @@
 	# Get all Intune Health Scripts
     $healthScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceHealthScripts" | Get-MGGraphAllPages
 
-	if ($healthScripts.value -ne "") {
+	if ($healthScripts -and $healthScripts.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Device Health Scripts")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
@@ -31,7 +31,7 @@
     # Get all assignments from all policies
     $healthScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceHealthScripts" | Get-MGGraphAllPages
 
-	if ($healthScripts.value -ne "") {
+	if ($healthScripts -and $healthScripts.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Device Health Scripts\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntent.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupDeviceManagementIntent {
     Write-Verbose "Requesting Intents"
     $intents = Get-MgBetaDeviceManagementIntent -all
 
-	if ($intents.value -ne "") {
+	if ($intents -and $intents.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Device Management Intents")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntent.ps1
@@ -25,7 +25,7 @@ function Invoke-IntuneBackupDeviceManagementIntent {
 
     #Connect to MS-Graph if required
     if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
     }
 
     Write-Verbose "Requesting Intents"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntentAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntentAssignment.ps1
@@ -1,0 +1,68 @@
+function Invoke-IntuneBackupDeviceManagementIntentAssignment {
+    <#
+    .SYNOPSIS
+    Backup Intune Device Management Intent Assignments
+
+    .DESCRIPTION
+    Backup Intune Device Management Intent Assignments (Endpoint Security policy assignments) as JSON files per Intent to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupDeviceManagementIntentAssignment -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
+    }
+
+    Write-Verbose "Requesting Device Management Intents"
+    $intents = Get-MgBetaDeviceManagementIntent -all
+
+    if ($intents -and $intents.Count -gt 0) {
+
+        foreach ($intent in $intents) {
+            # Get the corresponding Device Management Template
+            Write-Verbose "Requesting Template for Intent: $($intent.displayName)"
+            $template = Get-MgBetaDeviceManagementTemplate -DeviceManagementTemplateId $($intent.templateId)
+
+            $templateDisplayName = ($template.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+
+            # Create folder if not exists
+            if (-not (Test-Path "$Path\Device Management Intents\$templateDisplayName")) {
+                $null = New-Item -Path "$Path\Device Management Intents\$templateDisplayName" -ItemType Directory
+            }
+
+            # Get intent assignments
+            Write-Verbose "Requesting Assignments for Intent: $($intent.displayName)"
+            $intentAssignments = Get-MgBetaDeviceManagementIntentAssignment -DeviceManagementIntentId $intent.id -all
+
+            if ($intentAssignments -and $intentAssignments.Count -gt 0) {
+                $fileName = ("$($template.id)_$($intent.displayName)").Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+                $intentAssignments | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Device Management Intents\$templateDisplayName\Assignments\$fileName.json"
+
+                [PSCustomObject]@{
+                    "Action" = "Backup"
+                    "Type"   = "Device Management Intent Assignment"
+                    "Name"   = $intent.displayName
+                    "Path"   = "Device Management Intents\$templateDisplayName\Assignments\$fileName.json"
+                }
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScript.ps1
@@ -30,8 +30,8 @@ function Invoke-IntuneBackupDeviceManagementScript {
 
     # Get all device management scripts
     $deviceManagementScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceManagementScripts" | Get-MgGraphAllPages
-	
-	if ($deviceManagementScripts.value -ne "") {
+
+	if ($deviceManagementScripts -and $deviceManagementScripts.Count -gt 0) {
 		
 	    # Create folder if not exists
 		if (-not (Test-Path "$Path\Device Management Scripts\Script Content")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScriptAssignment.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupDeviceManagementScriptAssignment {
     # Get all assignments from all policies
     $deviceManagementScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceManagementScripts" | Get-MgGraphAllPages
 
-	if ($deviceManagementScripts.value -ne "") {
+	if ($deviceManagementScripts -and $deviceManagementScripts.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Device Management Scripts\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfigurationAssignment.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneBackupGroupPolicyConfigurationAssignment {
     # Get all assignments from all policies
     $groupPolicyConfigurations = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/groupPolicyConfigurations" | Get-MgGraphAllPages
 
-	if ($groupPolicyConfigurations.value -ne "") {
+	if ($groupPolicyConfigurations -and $groupPolicyConfigurations.Count -gt 0) {
 
 		# Create folder if not exists
 		if (-not (Test-Path "$Path\Administrative Templates\Assignments")) {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupIntuneBrandingProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupIntuneBrandingProfile.ps1
@@ -1,0 +1,68 @@
+function Invoke-IntuneBackupIntuneBrandingProfile {
+    <#
+    .SYNOPSIS
+    Backup Intune Branding Profiles
+
+    .DESCRIPTION
+    Backup Intune Branding Profiles (Company Portal customization) as JSON files per profile to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupIntuneBrandingProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementApps.ReadWrite.All"
+    }
+
+    # Get all Intune Branding Profiles
+    $brandingProfiles = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/intuneBrandingProfiles" | Get-MGGraphAllPages
+
+    if ($brandingProfiles -and $brandingProfiles.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Intune Branding Profiles")) {
+            $null = New-Item -Path "$Path\Intune Branding Profiles" -ItemType Directory
+        }
+
+        foreach ($brandingProfile in $brandingProfiles) {
+            # Skip if profileName is null or empty
+            if ([string]::IsNullOrEmpty($brandingProfile.profileName)) {
+                Write-Warning "Skipping Intune Branding Profile with null or empty profileName (ID: $($brandingProfile.id))"
+                continue
+            }
+
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $brandingProfile.profileName
+            } else {
+                $fileName = ($brandingProfile.profileName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $brandingProfile | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Intune Branding Profiles\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Intune Branding Profile"
+                "Name"   = $brandingProfile.profileName
+                "Path"   = "Intune Branding Profiles\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupMobileAppConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupMobileAppConfiguration.ps1
@@ -1,0 +1,68 @@
+function Invoke-IntuneBackupMobileAppConfiguration {
+    <#
+    .SYNOPSIS
+    Backup Mobile App Configurations (Device-level)
+
+    .DESCRIPTION
+    Backup Mobile App Configurations (iOS, Android) as JSON files per configuration to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupMobileAppConfiguration -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementApps.ReadWrite.All"
+    }
+
+    # Get all Mobile App Configurations
+    $mobileAppConfigurations = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceAppManagement/mobileAppConfigurations" | Get-MGGraphAllPages
+
+    if ($mobileAppConfigurations -and $mobileAppConfigurations.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Mobile App Configurations")) {
+            $null = New-Item -Path "$Path\Mobile App Configurations" -ItemType Directory
+        }
+
+        foreach ($mobileAppConfiguration in $mobileAppConfigurations) {
+            # Skip if displayName is null or empty
+            if ([string]::IsNullOrEmpty($mobileAppConfiguration.displayName)) {
+                Write-Warning "Skipping Mobile App Configuration with null or empty displayName (ID: $($mobileAppConfiguration.id))"
+                continue
+            }
+
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $mobileAppConfiguration.displayName
+            } else {
+                $fileName = ($mobileAppConfiguration.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $mobileAppConfiguration | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Mobile App Configurations\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Mobile App Configuration"
+                "Name"   = $mobileAppConfiguration.displayName
+                "Path"   = "Mobile App Configurations\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupNamedLocation.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupNamedLocation.ps1
@@ -1,0 +1,62 @@
+function Invoke-IntuneBackupNamedLocation {
+    <#
+    .SYNOPSIS
+    Backup Named Locations
+
+    .DESCRIPTION
+    Backup Named Locations (IP and Country-based) as JSON files per location to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneBackupNamedLocation -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "v1.0"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "Policy.Read.All"
+    }
+
+    # Get all Named Locations
+    $namedLocations = Invoke-MgGraphRequest -Uri "$ApiVersion/identity/conditionalAccess/namedLocations" | Get-MGGraphAllPages
+
+    if ($namedLocations -and $namedLocations.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Named Locations")) {
+            $null = New-Item -Path "$Path\Named Locations" -ItemType Directory
+        }
+
+        foreach ($namedLocation in $namedLocations) {
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $namedLocation.displayName
+            } else {
+                $fileName = ($namedLocation.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $namedLocation | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Named Locations\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Named Location"
+                "Name"   = $namedLocation.displayName
+                "Path"   = "Named Locations\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupNotificationTemplate.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupNotificationTemplate.ps1
@@ -1,0 +1,69 @@
+function Invoke-IntuneBackupNotificationTemplate {
+    <#
+    .SYNOPSIS
+    Backup Notification Message Templates
+
+    .DESCRIPTION
+    Backup Notification Message Templates as JSON files per template to the specified Path.
+    These templates are used for compliance notification messages.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneBackupNotificationTemplate -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "v1.0"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementServiceConfig.ReadWrite.All"
+    }
+
+    # Get all Notification Message Templates with localized messages expanded
+    $notificationTemplates = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/notificationMessageTemplates?`$expand=localizedNotificationMessages" | Get-MGGraphAllPages
+
+    if ($notificationTemplates -and $notificationTemplates.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Notification Templates")) {
+            $null = New-Item -Path "$Path\Notification Templates" -ItemType Directory
+        }
+
+        foreach ($notificationTemplate in $notificationTemplates) {
+            # Skip if displayName is null or empty
+            if ([string]::IsNullOrEmpty($notificationTemplate.displayName)) {
+                Write-Warning "Skipping Notification Template with null or empty displayName (ID: $($notificationTemplate.id))"
+                continue
+            }
+
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $notificationTemplate.displayName
+            } else {
+                $fileName = ($notificationTemplate.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $notificationTemplate | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Notification Templates\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Notification Template"
+                "Name"   = $notificationTemplate.displayName
+                "Path"   = "Notification Templates\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupPolicySet.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupPolicySet.ps1
@@ -1,0 +1,77 @@
+function Invoke-IntuneBackupPolicySet {
+    <#
+    .SYNOPSIS
+    Backup Intune Policy Sets
+
+    .DESCRIPTION
+    Backup Intune Policy Sets as JSON files per policy set to the specified Path.
+    Policy Sets are collections of policies grouped together for easier management.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupPolicySet -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Policy Sets (without expand - not supported by API)
+    $policySets = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceAppManagement/policySets" | Get-MGGraphAllPages
+
+    if ($policySets -and $policySets.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Policy Sets")) {
+            $null = New-Item -Path "$Path\Policy Sets" -ItemType Directory
+        }
+
+        foreach ($policySet in $policySets) {
+            # Skip if displayName is null or empty
+            if ([string]::IsNullOrEmpty($policySet.displayName)) {
+                Write-Warning "Skipping Policy Set with null or empty displayName (ID: $($policySet.id))"
+                continue
+            }
+
+            # Fetch items for this policy set separately (expand not supported on collection query)
+            try {
+                $policySetWithItems = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceAppManagement/policySets/$($policySet.id)?`$expand=items" -ErrorAction Stop
+                $policySet = $policySetWithItems
+            } catch {
+                Write-Verbose "Could not expand items for Policy Set '$($policySet.displayName)' - backing up without items" -Verbose
+            }
+
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $policySet.displayName
+            } else {
+                $fileName = ($policySet.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $policySet | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Policy Sets\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Policy Set"
+                "Name"   = $policySet.displayName
+                "Path"   = "Policy Sets\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupRoleDefinition.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupRoleDefinition.ps1
@@ -1,0 +1,68 @@
+function Invoke-IntuneBackupRoleDefinition {
+    <#
+    .SYNOPSIS
+    Backup Intune Role Definitions
+
+    .DESCRIPTION
+    Backup Intune Role Definitions as JSON files per role to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupRoleDefinition -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementRBAC.ReadWrite.All"
+    }
+
+    # Get all Role Definitions
+    $roleDefinitions = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/roleDefinitions" | Get-MGGraphAllPages
+
+    if ($roleDefinitions -and $roleDefinitions.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Role Definitions")) {
+            $null = New-Item -Path "$Path\Role Definitions" -ItemType Directory
+        }
+
+        foreach ($roleDefinition in $roleDefinitions) {
+            # Skip if displayName is null or empty
+            if ([string]::IsNullOrEmpty($roleDefinition.displayName)) {
+                Write-Warning "Skipping Role Definition with null or empty displayName (ID: $($roleDefinition.id))"
+                continue
+            }
+
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $roleDefinition.displayName
+            } else {
+                $fileName = ($roleDefinition.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $roleDefinition | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Role Definitions\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Role Definition"
+                "Name"   = $roleDefinition.displayName
+                "Path"   = "Role Definitions\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupRoleScopeTag.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupRoleScopeTag.ps1
@@ -1,0 +1,62 @@
+function Invoke-IntuneBackupRoleScopeTag {
+    <#
+    .SYNOPSIS
+    Backup Intune Role Scope Tags
+
+    .DESCRIPTION
+    Backup Intune Role Scope Tags as JSON files per scope tag to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupRoleScopeTag -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementRBAC.ReadWrite.All"
+    }
+
+    # Get all Role Scope Tags
+    $roleScopeTags = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/roleScopeTags" | Get-MGGraphAllPages
+
+    if ($roleScopeTags -and $roleScopeTags.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Role Scope Tags")) {
+            $null = New-Item -Path "$Path\Role Scope Tags" -ItemType Directory
+        }
+
+        foreach ($roleScopeTag in $roleScopeTags) {
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $roleScopeTag.displayName
+            } else {
+                $fileName = ($roleScopeTag.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $roleScopeTag | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Role Scope Tags\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Role Scope Tag"
+                "Name"   = $roleScopeTag.displayName
+                "Path"   = "Role Scope Tags\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupTargetedManagedAppConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupTargetedManagedAppConfiguration.ps1
@@ -1,0 +1,68 @@
+function Invoke-IntuneBackupTargetedManagedAppConfiguration {
+    <#
+    .SYNOPSIS
+    Backup Targeted Managed App Configurations (MAM)
+
+    .DESCRIPTION
+    Backup Targeted Managed App Configurations (Mobile Application Management) as JSON files per configuration to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupTargetedManagedAppConfiguration -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementApps.ReadWrite.All"
+    }
+
+    # Get all Targeted Managed App Configurations
+    $targetedManagedAppConfigurations = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceAppManagement/targetedManagedAppConfigurations" | Get-MGGraphAllPages
+
+    if ($targetedManagedAppConfigurations -and $targetedManagedAppConfigurations.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Targeted Managed App Configurations")) {
+            $null = New-Item -Path "$Path\Targeted Managed App Configurations" -ItemType Directory
+        }
+
+        foreach ($targetedManagedAppConfiguration in $targetedManagedAppConfigurations) {
+            # Skip if displayName is null or empty
+            if ([string]::IsNullOrEmpty($targetedManagedAppConfiguration.displayName)) {
+                Write-Warning "Skipping Targeted Managed App Configuration with null or empty displayName (ID: $($targetedManagedAppConfiguration.id))"
+                continue
+            }
+
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $targetedManagedAppConfiguration.displayName
+            } else {
+                $fileName = ($targetedManagedAppConfiguration.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $targetedManagedAppConfiguration | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Targeted Managed App Configurations\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Targeted Managed App Configuration"
+                "Name"   = $targetedManagedAppConfiguration.displayName
+                "Path"   = "Targeted Managed App Configurations\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupTermsAndConditions.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupTermsAndConditions.ps1
@@ -1,0 +1,68 @@
+function Invoke-IntuneBackupTermsAndConditions {
+    <#
+    .SYNOPSIS
+    Backup Intune Terms and Conditions
+
+    .DESCRIPTION
+    Backup Intune Terms and Conditions as JSON files per policy to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupTermsAndConditions -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementServiceConfig.ReadWrite.All"
+    }
+
+    # Get all Terms and Conditions
+    $termsAndConditions = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/termsAndConditions" | Get-MGGraphAllPages
+
+    if ($termsAndConditions -and $termsAndConditions.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Terms and Conditions")) {
+            $null = New-Item -Path "$Path\Terms and Conditions" -ItemType Directory
+        }
+
+        foreach ($termsAndCondition in $termsAndConditions) {
+            # Skip if displayName is null or empty
+            if ([string]::IsNullOrEmpty($termsAndCondition.displayName)) {
+                Write-Warning "Skipping Terms and Conditions with null or empty displayName (ID: $($termsAndCondition.id))"
+                continue
+            }
+
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $termsAndCondition.displayName
+            } else {
+                $fileName = ($termsAndCondition.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $termsAndCondition | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Terms and Conditions\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Terms and Conditions"
+                "Name"   = $termsAndCondition.displayName
+                "Path"   = "Terms and Conditions\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupWindowsDriverUpdateProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupWindowsDriverUpdateProfile.ps1
@@ -1,0 +1,62 @@
+function Invoke-IntuneBackupWindowsDriverUpdateProfile {
+    <#
+    .SYNOPSIS
+    Backup Windows Driver Update Profiles
+
+    .DESCRIPTION
+    Backup Windows Driver Update Profiles as JSON files per profile to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupWindowsDriverUpdateProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Windows Driver Update Profiles
+    $driverUpdateProfiles = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/windowsDriverUpdateProfiles" | Get-MGGraphAllPages
+
+    if ($driverUpdateProfiles -and $driverUpdateProfiles.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Windows Driver Update Profiles")) {
+            $null = New-Item -Path "$Path\Windows Driver Update Profiles" -ItemType Directory
+        }
+
+        foreach ($driverUpdateProfile in $driverUpdateProfiles) {
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $driverUpdateProfile.displayName
+            } else {
+                $fileName = ($driverUpdateProfile.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $driverUpdateProfile | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Windows Driver Update Profiles\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Windows Driver Update Profile"
+                "Name"   = $driverUpdateProfile.displayName
+                "Path"   = "Windows Driver Update Profiles\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupWindowsFeatureUpdateProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupWindowsFeatureUpdateProfile.ps1
@@ -1,0 +1,62 @@
+function Invoke-IntuneBackupWindowsFeatureUpdateProfile {
+    <#
+    .SYNOPSIS
+    Backup Windows Feature Update Profiles
+
+    .DESCRIPTION
+    Backup Windows Feature Update Profiles as JSON files per profile to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupWindowsFeatureUpdateProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Windows Feature Update Profiles
+    $featureUpdateProfiles = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/windowsFeatureUpdateProfiles" | Get-MGGraphAllPages
+
+    if ($featureUpdateProfiles -and $featureUpdateProfiles.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Windows Feature Update Profiles")) {
+            $null = New-Item -Path "$Path\Windows Feature Update Profiles" -ItemType Directory
+        }
+
+        foreach ($featureUpdateProfile in $featureUpdateProfiles) {
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $featureUpdateProfile.displayName
+            } else {
+                $fileName = ($featureUpdateProfile.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $featureUpdateProfile | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Windows Feature Update Profiles\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Windows Feature Update Profile"
+                "Name"   = $featureUpdateProfile.displayName
+                "Path"   = "Windows Feature Update Profiles\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupWindowsQualityUpdateProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupWindowsQualityUpdateProfile.ps1
@@ -1,0 +1,62 @@
+function Invoke-IntuneBackupWindowsQualityUpdateProfile {
+    <#
+    .SYNOPSIS
+    Backup Windows Quality Update Profiles
+
+    .DESCRIPTION
+    Backup Windows Quality Update Profiles as JSON files per profile to the specified Path.
+
+    .PARAMETER Path
+    Path to store backup files
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneBackupWindowsQualityUpdateProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    # Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Windows Quality Update Profiles
+    $qualityUpdateProfiles = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/windowsQualityUpdateProfiles" | Get-MGGraphAllPages
+
+    if ($qualityUpdateProfiles -and $qualityUpdateProfiles.Count -gt 0) {
+
+        # Create folder if not exists
+        if (-not (Test-Path "$Path\Windows Quality Update Profiles")) {
+            $null = New-Item -Path "$Path\Windows Quality Update Profiles" -ItemType Directory
+        }
+
+        foreach ($qualityUpdateProfile in $qualityUpdateProfiles) {
+            # Use ConvertTo-SafeFilename if available, otherwise fallback to Split
+            if (Get-Command ConvertTo-SafeFilename -ErrorAction SilentlyContinue) {
+                $fileName = ConvertTo-SafeFilename -FileName $qualityUpdateProfile.displayName
+            } else {
+                $fileName = ($qualityUpdateProfile.displayName).Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+            }
+
+            $qualityUpdateProfile | ConvertTo-Json -Depth 100 | Out-File -LiteralPath "$Path\Windows Quality Update Profiles\$fileName.json"
+
+            [PSCustomObject]@{
+                "Action" = "Backup"
+                "Type"   = "Windows Quality Update Profile"
+                "Name"   = $qualityUpdateProfile.displayName
+                "Path"   = "Windows Quality Update Profiles\$fileName.json"
+            }
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
@@ -53,13 +53,14 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
 
         # Restore the App Protection Policy
         try {
-            $null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceAppManagement/managedAppPolicies" -ErrorAction Stop
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceAppManagement/managedAppPolicies" -ErrorAction Stop
 
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "App Protection Policy"
                 "Name"   = $appProtectionPolicyDisplayName
                 "Path"   = "App Protection Policies\$($appProtectionPolicy.Name)"
+                "Id"     = $createdPolicy.id
             }
         }
         catch {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAssignmentFilter.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAssignmentFilter.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreAssignmentFilter {
+    <#
+    .SYNOPSIS
+    Restore Intune Assignment Filters
+
+    .DESCRIPTION
+    Restore Intune Assignment Filters from JSON files per Assignment Filter from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupAssignmentFilter function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreAssignmentFilter -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Assignment Filters
+    $assignmentFilters = Get-ChildItem -Path "$Path\Assignment Filters" -File -ErrorAction SilentlyContinue
+
+    foreach ($assignmentFilter in $assignmentFilters) {
+        $assignmentFilterContent = Get-Content -LiteralPath $assignmentFilter.FullName -Raw | ConvertFrom-Json
+
+        $assignmentFilterDisplayName = $assignmentFilterContent.displayName
+
+        # Remove properties that are not available for creating a new assignment filter
+        $requestBody = $assignmentFilterContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, payloads
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Assignment Filter
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/assignmentFilters"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Assignment Filter"
+                "Name"   = $assignmentFilterDisplayName
+                "Path"   = "Assignment Filters\$($assignmentFilter.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$assignmentFilterDisplayName - Failed to restore Assignment Filter" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfile.ps1
@@ -41,12 +41,13 @@ function Invoke-IntuneRestoreAutopilotDeploymentProfile {
 
         # Restore the Deployment Profile
 		try {
-			$null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles" -ErrorAction Stop
+			$createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles" -ErrorAction Stop
 			[PSCustomObject]@{
 				"Action" = "Restore"
 				"Type"   = "Autopilot Deployment Profile"
 				"Name"   = $winAutopilotDeploymentProfileDisplayName
 				"Path"   = "Autopilot Deployment Profiles\$($winAutopilotDeploymentProfile.Name)"
+				"Id"     = $createdPolicy.id
 			}
 		}
 		catch {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment.ps1
@@ -59,10 +59,10 @@ function Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment {
         # Get the Autopilot Deployment Profile we are restoring the assignments for
         try {
             if ($restoreById) {
-                $winAutopilotDeploymentProfileObject = Invoke-MgGraphRequest -Uri "deviceManagement/windowsAutopilotDeploymentProfiles/$winAutopilotDeploymentProfileId"
+                $winAutopilotDeploymentProfileObject = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles/$winAutopilotDeploymentProfileId"
             }
             else {
-                $winAutopilotDeploymentProfileObject = Invoke-MgGraphRequest -Uri "deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MGGraphAllPages | Where-Object displayName -eq "$($winAutopilotDeploymentProfile.BaseName)"
+                $winAutopilotDeploymentProfileObject = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles" | Get-MGGraphAllPages | Where-Object displayName -eq "$($winAutopilotDeploymentProfile.BaseName)"
                 if (-not ($winAutopilotDeploymentProfileObject)) {
                     Write-Verbose "Error retrieving Intune Autopilot Deployment Profile for $($winAutopilotDeploymentProfile.FullName). Skipping assignment restore" -Verbose
                     continue
@@ -79,7 +79,7 @@ function Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment {
         try {
 			# FIXME: look into why POSTing to this Graph API endpoint currently results in error "403 Forbidden - FeatureNotEnabled",
             # although the user account has the required permissions as documented in https://docs.microsoft.com/en-us/graph/api/intune-shared-windowsautopilotdeploymentprofile-assign?view=graph-rest-beta
-            $null = Invoke-MgGraphRequest -Method POST -Content $requestBody.toString() -Uri "deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfileObject.id)/assign" -ErrorAction Stop
+            $null = Invoke-MgGraphRequest -Method POST -Content $requestBody.toString() -Uri "$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles/$($winAutopilotDeploymentProfileObject.id)/assign" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Autopilot Deployment Profile Assignments"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConditionalAccessPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConditionalAccessPolicy.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreConditionalAccessPolicy {
+    <#
+    .SYNOPSIS
+    Restore Conditional Access Policies
+
+    .DESCRIPTION
+    Restore Conditional Access Policies from JSON files per policy from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupConditionalAccessPolicy function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreConditionalAccessPolicy -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "Policy.Read.All", "Policy.ReadWrite.ConditionalAccess"
+    }
+
+    # Get all Conditional Access Policies
+    $conditionalAccessPolicies = Get-ChildItem -Path "$Path\Conditional Access" -File -ErrorAction SilentlyContinue
+
+    foreach ($conditionalAccessPolicy in $conditionalAccessPolicies) {
+        $conditionalAccessPolicyContent = Get-Content -LiteralPath $conditionalAccessPolicy.FullName -Raw | ConvertFrom-Json
+
+        $conditionalAccessPolicyDisplayName = $conditionalAccessPolicyContent.displayName
+
+        # Remove properties that are not available for creating a new policy
+        $requestBody = $conditionalAccessPolicyContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, modifiedDateTime
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Conditional Access Policy
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/identity/conditionalAccess/policies"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Conditional Access Policy"
+                "Name"   = $conditionalAccessPolicyDisplayName
+                "Path"   = "Conditional Access\$($conditionalAccessPolicy.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$conditionalAccessPolicyDisplayName - Failed to restore Conditional Access Policy" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
@@ -60,12 +60,13 @@ function Invoke-IntuneRestoreDeviceCompliancePolicy {
 
         # Restore the Device Compliance Policy
         try {
-            $null = Invoke-MgGraphRequest -Method POST -body $requestBodyJson.toString() -Uri "beta/deviceManagement/deviceCompliancePolicies" -ErrorAction Stop
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -body $requestBodyJson.toString() -Uri "beta/deviceManagement/deviceCompliancePolicies" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Compliance Policy"
                 "Name"   = $deviceCompliancePolicyDisplayName
                 "Path"   = "Device Compliance Policies\$($deviceCompliancePolicy.Name)"
+                "Id"     = $createdPolicy.id
             }
         }
         catch {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
@@ -55,12 +55,13 @@ function Invoke-IntuneRestoreDeviceConfiguration {
 
         # Restore the device configuration
         try {
-            $null = Invoke-MgGraphRequest -Method POST -body $requestBody.toString() -Uri "$ApiVersion/deviceManagement/deviceConfigurations" -ErrorAction Stop
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -body $requestBody.toString() -Uri "$ApiVersion/deviceManagement/deviceConfigurations" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Configuration"
                 "Name"   = $deviceConfigurationDisplayName
                 "Path"   = "Device Configurations\$($deviceConfiguration.Name)"
+                "Id"     = $createdPolicy.id
             }
         }
         catch {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceEnrollmentConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceEnrollmentConfiguration.ps1
@@ -1,0 +1,115 @@
+function Invoke-IntuneRestoreDeviceEnrollmentConfiguration {
+    <#
+    .SYNOPSIS
+    Restore Intune Device Enrollment Configurations
+
+    .DESCRIPTION
+    Restore Intune Device Enrollment Configurations (Enrollment Restrictions and Enrollment Status Page profiles) from JSON files from the specified Path.
+    Handles priority conflicts by automatically finding the next available priority value.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupDeviceEnrollmentConfiguration function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreDeviceEnrollmentConfiguration -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementServiceConfig.ReadWrite.All"
+    }
+
+    # Get existing enrollment configurations to check for priority conflicts
+    try {
+        $existingConfigurations = Invoke-MgGraphRequest -Method GET -Uri "$ApiVersion/deviceManagement/deviceEnrollmentConfigurations" -ErrorAction Stop
+        $existingPriorities = @()
+        if ($existingConfigurations.value) {
+            $existingPriorities = $existingConfigurations.value | Where-Object { $_.priority -ne $null } | Select-Object -ExpandProperty priority
+        }
+        Write-Verbose "Found $($existingPriorities.Count) existing enrollment configurations with priorities" -Verbose
+    }
+    catch {
+        Write-Warning "Could not retrieve existing enrollment configurations. Priority conflicts may occur."
+        $existingPriorities = @()
+    }
+
+    # Get all Device Enrollment Configurations
+    $enrollmentConfigurations = Get-ChildItem -Path "$Path\Device Enrollment Configurations" -File -ErrorAction SilentlyContinue
+
+    foreach ($enrollmentConfiguration in $enrollmentConfigurations) {
+        $enrollmentConfigurationContent = Get-Content -LiteralPath $enrollmentConfiguration.FullName -Raw | ConvertFrom-Json
+
+        $enrollmentConfigurationDisplayName = $enrollmentConfigurationContent.displayName
+
+        # Skip default/global enrollment restrictions and unsupported types (these cannot be created, only modified)
+        $unsupportedTypes = @(
+            "#microsoft.graph.windowsRestoreDeviceEnrollmentConfiguration"  # Windows Restore config - built-in only
+        )
+
+        if ($enrollmentConfigurationDisplayName -like "Global-*" -or
+            $enrollmentConfigurationDisplayName -eq "All users and all devices" -or
+            $enrollmentConfigurationContent.'@odata.type' -in $unsupportedTypes) {
+            Write-Verbose "Skipping built-in Device Enrollment Configuration: $enrollmentConfigurationDisplayName" -Verbose
+            continue
+        }
+
+        # Remove properties that are not available for creating a new enrollment configuration
+        $requestBody = $enrollmentConfigurationContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, version, modifiedDateTime, supportsScopeTags
+
+        # Handle priority conflicts - find next available priority if the current one is taken
+        if ($requestBody.priority -ne $null) {
+            $originalPriority = [int]$requestBody.priority
+            if ($existingPriorities -contains $originalPriority) {
+                # Priority conflict detected - find next available priority
+                $maxPriority = [int]($existingPriorities | Measure-Object -Maximum).Maximum
+                $newPriority = [int]($maxPriority + 1)
+
+                Write-Verbose "$enrollmentConfigurationDisplayName - Priority conflict detected (priority $originalPriority already exists). Using priority $newPriority instead." -Verbose
+                $requestBody.priority = $newPriority
+
+                # Add the new priority to the tracking list
+                $existingPriorities += $newPriority
+            }
+            else {
+                Write-Verbose "$enrollmentConfigurationDisplayName - Using original priority: $originalPriority" -Verbose
+                # Add this priority to the tracking list
+                $existingPriorities += $originalPriority
+            }
+        }
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Debug: Log the request body
+        Write-Verbose "REQUEST BODY FOR $enrollmentConfigurationDisplayName :" -Verbose
+        Write-Verbose $requestBodyJson -Verbose
+
+        # Restore the Device Enrollment Configuration
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/deviceEnrollmentConfigurations" -ErrorAction Stop
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Device Enrollment Configuration"
+                "Name"   = $enrollmentConfigurationDisplayName
+                "Path"   = "Device Enrollment Configurations\$($enrollmentConfiguration.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$enrollmentConfigurationDisplayName - Failed to restore Device Enrollment Configuration" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceHealthScript.ps1
@@ -42,12 +42,13 @@ function Invoke-IntuneRestoreDeviceHealthScript {
         # Restore the device health script (excluding Microsoft builtin scripts)
 		if (-not ($requestBodyObject.publisher -eq "Microsoft")) {
 			try {
-				$null = Invoke-MgGraphRequest -Method POST -body $requestBody.toString() -Uri "$ApiVersion/deviceManagement/deviceHealthScripts" -ErrorAction Stop
+				$createdPolicy = Invoke-MgGraphRequest -Method POST -body $requestBody.toString() -Uri "$ApiVersion/deviceManagement/deviceHealthScripts" -ErrorAction Stop
 				[PSCustomObject]@{
 					"Action" = "Restore"
 					"Type"   = "Device Health Script"
 					"Name"   = $deviceHealthScriptDisplayName
 					"Path"   = "Device Health Scripts\$($deviceHealthScript.Name)"
+					"Id"     = $createdPolicy.id
 				}
 			}
 			catch {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
@@ -60,12 +60,13 @@ function Invoke-IntuneRestoreDeviceManagementIntent {
         $deviceManagementIntentJson = $($deviceManagementIntentContent | convertto-json -Depth 100)
         # Restore the device management intent
         try {
-            New-MgBetaDeviceManagementTemplateInstance -DeviceManagementTemplateId $templateId -BodyParameter $deviceManagementIntentJson
+            $createdPolicy = New-MgBetaDeviceManagementTemplateInstance -DeviceManagementTemplateId $templateId -BodyParameter $deviceManagementIntentJson
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Management Intent"
                 "Name"   = $deviceManagementIntentDisplayName
                 "Path"   = "Device Management Intents\$($deviceManagementIntent.Name)"
+                "Id"     = $createdPolicy.Id
             }
         }
         catch {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
@@ -44,12 +44,13 @@ function Invoke-IntuneRestoreDeviceManagementScript {
 
         # Restore the device management script
         try {
-            $null = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$apiVersion/deviceManagement/deviceManagementScripts" -ErrorAction Stop
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBody.toString() -Uri "$apiVersion/deviceManagement/deviceManagementScripts" -ErrorAction Stop
             [PSCustomObject]@{
                 "Action" = "Restore"
                 "Type"   = "Device Management Script"
                 "Name"   = $deviceManagementScriptDisplayName
                 "Path"   = "Device Management Scripts\$($deviceManagementScript.Name)"
+                "Id"     = $createdPolicy.id
             }
         }
         catch {

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreIntuneBrandingProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreIntuneBrandingProfile.ps1
@@ -1,0 +1,81 @@
+function Invoke-IntuneRestoreIntuneBrandingProfile {
+    <#
+    .SYNOPSIS
+    Restore Intune Branding Profiles
+
+    .DESCRIPTION
+    Restore Intune Branding Profiles (Company Portal branding) from JSON files per profile from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupIntuneBrandingProfile function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreIntuneBrandingProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementServiceConfig.ReadWrite.All"
+    }
+
+    # Get all Intune Branding Profiles
+    $brandingProfiles = Get-ChildItem -Path "$Path\Intune Branding Profiles" -File -ErrorAction SilentlyContinue
+
+    foreach ($brandingProfile in $brandingProfiles) {
+        $brandingProfileContent = Get-Content -LiteralPath $brandingProfile.FullName -Raw | ConvertFrom-Json
+
+        $brandingProfileName = $brandingProfileContent.profileName
+
+        # Skip the default branding profile (can only be updated, not created)
+        if ($brandingProfileName -like "Default*" -or $brandingProfileContent.id -eq "00000000-0000-0000-0000-000000000000") {
+            Write-Verbose "Skipping built-in Branding Profile: $brandingProfileName" -Verbose
+            continue
+        }
+
+        # Remove properties that are not available for creating a new profile
+        $requestBody = $brandingProfileContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, isDefaultProfile
+
+        # Validate profileName length (max 40 characters for Intune Branding Profiles - uses profileName not displayName)
+        if ($requestBody.profileName.Length -gt 40) {
+            Write-Warning "$brandingProfileName - Profile name exceeds 40 characters, truncating..."
+            $requestBody.profileName = $requestBody.profileName.Substring(0, 37) + "..."
+        }
+
+        # Validate displayName length (max 40 characters for Intune Branding Profiles)
+        if ($requestBody.displayName -and $requestBody.displayName.Length -gt 40) {
+            Write-Warning "$brandingProfileName - Display name exceeds 40 characters, truncating..."
+            $requestBody.displayName = $requestBody.displayName.Substring(0, 37) + "..."
+        }
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Intune Branding Profile
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/intuneBrandingProfiles"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Intune Branding Profile"
+                "Name"   = $brandingProfileName
+                "Path"   = "Intune Branding Profiles\$($brandingProfile.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$brandingProfileName - Failed to restore Intune Branding Profile" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreMobileAppConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreMobileAppConfiguration.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreMobileAppConfiguration {
+    <#
+    .SYNOPSIS
+    Restore Intune Mobile App Configurations
+
+    .DESCRIPTION
+    Restore Intune Mobile App Configurations (device-level, iOS/Android) from JSON files per configuration from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupMobileAppConfiguration function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreMobileAppConfiguration -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "v1.0"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All"
+    }
+
+    # Get all Mobile App Configurations
+    $mobileAppConfigurations = Get-ChildItem -Path "$Path\Mobile App Configurations" -File -ErrorAction SilentlyContinue
+
+    foreach ($mobileAppConfiguration in $mobileAppConfigurations) {
+        $mobileAppConfigurationContent = Get-Content -LiteralPath $mobileAppConfiguration.FullName -Raw | ConvertFrom-Json
+
+        $mobileAppConfigurationDisplayName = $mobileAppConfigurationContent.displayName
+
+        # Remove properties that are not available for creating a new configuration
+        $requestBody = $mobileAppConfigurationContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, version
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Mobile App Configuration
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceAppManagement/mobileAppConfigurations"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Mobile App Configuration"
+                "Name"   = $mobileAppConfigurationDisplayName
+                "Path"   = "Mobile App Configurations\$($mobileAppConfiguration.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$mobileAppConfigurationDisplayName - Failed to restore Mobile App Configuration" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreNamedLocation.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreNamedLocation.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreNamedLocation {
+    <#
+    .SYNOPSIS
+    Restore Named Locations
+
+    .DESCRIPTION
+    Restore Named Locations (IP and Country-based) from JSON files per Named Location from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupNamedLocation function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreNamedLocation -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "Policy.Read.All", "Policy.ReadWrite.ConditionalAccess"
+    }
+
+    # Get all Named Locations
+    $namedLocations = Get-ChildItem -Path "$Path\Named Locations" -File -ErrorAction SilentlyContinue
+
+    foreach ($namedLocation in $namedLocations) {
+        $namedLocationContent = Get-Content -LiteralPath $namedLocation.FullName -Raw | ConvertFrom-Json
+
+        $namedLocationDisplayName = $namedLocationContent.displayName
+
+        # Remove properties that are not available for creating a new named location
+        $requestBody = $namedLocationContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, modifiedDateTime
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Named Location
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/identity/conditionalAccess/namedLocations"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Named Location"
+                "Name"   = $namedLocationDisplayName
+                "Path"   = "Named Locations\$($namedLocation.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$namedLocationDisplayName - Failed to restore Named Location" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreNotificationTemplate.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreNotificationTemplate.ps1
@@ -1,0 +1,126 @@
+function Invoke-IntuneRestoreNotificationTemplate {
+    <#
+    .SYNOPSIS
+    Restore Intune Notification Templates
+
+    .DESCRIPTION
+    Restore Intune Notification Templates (for compliance notifications) from JSON files per template from the specified Path.
+    Uses a two-step process: 1) Create template, 2) Add localized messages
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupNotificationTemplate function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreNotificationTemplate -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "v1.0"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementServiceConfig.ReadWrite.All"
+    }
+
+    # Get all Notification Templates
+    $notificationTemplates = Get-ChildItem -Path "$Path\Notification Templates" -File -ErrorAction SilentlyContinue
+
+    foreach ($notificationTemplate in $notificationTemplates) {
+        $notificationTemplateContent = Get-Content -LiteralPath $notificationTemplate.FullName -Raw | ConvertFrom-Json
+
+        $notificationTemplateDisplayName = $notificationTemplateContent.displayName
+
+        # Skip default notification templates
+        if ($notificationTemplateDisplayName -like "*Default*" -or $notificationTemplateContent.id -match "^0000") {
+            Write-Verbose "Skipping built-in Notification Template: $notificationTemplateDisplayName" -Verbose
+            continue
+        }
+
+        # Save localizedNotificationMessages for later (Step 2)
+        $localizedMessages = $notificationTemplateContent.localizedNotificationMessages
+
+        # Step 1: Create the template WITHOUT localizedNotificationMessages
+        # Remove properties that cannot be set during creation
+        $requestBody = $notificationTemplateContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, modifiedDateTime, supportsScopeTags, 'localizedNotificationMessages@odata.context', localizedNotificationMessages
+
+        # Add @odata.type to ensure proper type
+        if (-not $requestBody.'@odata.type') {
+            $requestBody | Add-Member -MemberType NoteProperty -Name "@odata.type" -Value "#microsoft.graph.notificationMessageTemplate" -Force
+        }
+
+        # Remove defaultLocale if present - it may cause issues during creation
+        if ($requestBody.PSObject.Properties.Name -contains 'defaultLocale') {
+            $requestBody.PSObject.Properties.Remove('defaultLocale')
+            Write-Verbose "$notificationTemplateDisplayName - Removed defaultLocale property" -Verbose
+        }
+
+        # Remove description if present - it may cause issues during creation
+        if ($requestBody.PSObject.Properties.Name -contains 'description') {
+            $requestBody.PSObject.Properties.Remove('description')
+            Write-Verbose "$notificationTemplateDisplayName - Removed description property" -Verbose
+        }
+
+        # Validate displayName length (max 50 characters for Notification Templates)
+        if ($requestBody.displayName.Length -gt 50) {
+            Write-Warning "$notificationTemplateDisplayName - Display name exceeds 50 characters, truncating..."
+            $requestBody.displayName = $requestBody.displayName.Substring(0, 47) + "..."
+        }
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Debug: Log the request body
+        Write-Verbose "REQUEST BODY FOR $notificationTemplateDisplayName :" -Verbose
+        Write-Verbose $requestBodyJson -Verbose
+
+        # Step 1: Create the Notification Template
+        try {
+            $createdTemplate = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/notificationMessageTemplates" -ErrorAction Stop
+            Write-Verbose "$notificationTemplateDisplayName - Template created successfully (ID: $($createdTemplate.id))" -Verbose
+
+            # Step 2: Add localized notification messages
+            if ($localizedMessages -and $localizedMessages.Count -gt 0) {
+                Write-Verbose "$notificationTemplateDisplayName - Adding $($localizedMessages.Count) localized message(s)..." -Verbose
+
+                foreach ($message in $localizedMessages) {
+                    # Remove read-only properties from localized message
+                    $messageBody = $message | Select-Object -Property * -ExcludeProperty id, lastModifiedDateTime, isDefault
+
+                    # Add @odata.type for localized message
+                    $messageBody | Add-Member -MemberType NoteProperty -Name "@odata.type" -Value "#microsoft.graph.localizedNotificationMessage" -Force
+
+                    $messageBodyJson = $messageBody | ConvertTo-Json -Depth 10
+
+                    try {
+                        $createdMessage = Invoke-MgGraphRequest -Method POST -Body $messageBodyJson.toString() -Uri "$ApiVersion/deviceManagement/notificationMessageTemplates/$($createdTemplate.id)/localizedNotificationMessages" -ErrorAction Stop
+                        Write-Verbose "$notificationTemplateDisplayName - Added localized message for locale: $($message.locale)" -Verbose
+                    }
+                    catch {
+                        Write-Warning "$notificationTemplateDisplayName - Failed to add localized message for locale $($message.locale): $($_.Exception.Message)"
+                    }
+                }
+            }
+
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Notification Template"
+                "Name"   = $notificationTemplateDisplayName
+                "Path"   = "Notification Templates\$($notificationTemplate.Name)"
+                "Id"     = $createdTemplate.id
+            }
+        }
+        catch {
+            Write-Verbose "$notificationTemplateDisplayName - Failed to restore Notification Template" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestorePolicySet.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestorePolicySet.ps1
@@ -1,0 +1,71 @@
+function Invoke-IntuneRestorePolicySet {
+    <#
+    .SYNOPSIS
+    Restore Intune Policy Sets
+
+    .DESCRIPTION
+    Restore Intune Policy Sets (grouped policies) from JSON files per policy set from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupPolicySet function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneRestorePolicySet -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Policy Sets
+    $policySets = Get-ChildItem -Path "$Path\Policy Sets" -File -ErrorAction SilentlyContinue
+
+    foreach ($policySet in $policySets) {
+        $policySetContent = Get-Content -LiteralPath $policySet.FullName -Raw | ConvertFrom-Json
+
+        $policySetDisplayName = $policySetContent.displayName
+
+        # Remove properties that are not available for creating a new policy set
+        # Note: items property contains references to policies that need to exist first
+        $requestBody = $policySetContent | Select-Object -Property displayName, description
+
+        # Add items if they exist and have valid policy references
+        # This is a simplified restore - full item restoration would require mapping old IDs to new IDs
+        if ($policySetContent.items -and $policySetContent.items.Count -gt 0) {
+            Write-Verbose "$policySetDisplayName - Policy Set contains $($policySetContent.items.Count) items that will need to be added separately" -Verbose
+        }
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Policy Set
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceAppManagement/policySets"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Policy Set"
+                "Name"   = $policySetDisplayName
+                "Path"   = "Policy Sets\$($policySet.Name)"
+                "Id"     = $createdPolicy.id
+            }
+            Write-Verbose "$policySetDisplayName - Policy Set restored successfully. Note: Policy items need to be added manually or through assignment restore." -Verbose
+        }
+        catch {
+            Write-Verbose "$policySetDisplayName - Failed to restore Policy Set" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreRoleDefinition.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreRoleDefinition.ps1
@@ -1,0 +1,81 @@
+function Invoke-IntuneRestoreRoleDefinition {
+    <#
+    .SYNOPSIS
+    Restore Intune Role Definitions
+
+    .DESCRIPTION
+    Restore Intune Role Definitions (custom RBAC roles) from JSON files per role from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupRoleDefinition function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreRoleDefinition -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "v1.0"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementRBAC.ReadWrite.All"
+    }
+
+    # Get all Role Definitions
+    $roleDefinitions = Get-ChildItem -Path "$Path\Role Definitions" -File -ErrorAction SilentlyContinue
+
+    foreach ($roleDefinition in $roleDefinitions) {
+        $roleDefinitionContent = Get-Content -LiteralPath $roleDefinition.FullName -Raw | ConvertFrom-Json
+
+        $roleDefinitionDisplayName = $roleDefinitionContent.displayName
+
+        # Skip built-in roles (isBuiltIn = true)
+        if ($roleDefinitionContent.isBuiltIn -eq $true) {
+            Write-Verbose "Skipping built-in Role Definition: $roleDefinitionDisplayName" -Verbose
+            continue
+        }
+
+        # Remove properties that are not available for creating a new role definition
+        $requestBody = $roleDefinitionContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, isBuiltInRoleDefinition
+
+        # Remove 'actions' property from rolePermissions and permissions arrays (read-only computed property)
+        if ($requestBody.rolePermissions) {
+            foreach ($permission in $requestBody.rolePermissions) {
+                $permission.PSObject.Properties.Remove('actions')
+            }
+        }
+        if ($requestBody.permissions) {
+            foreach ($permission in $requestBody.permissions) {
+                $permission.PSObject.Properties.Remove('actions')
+            }
+        }
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Role Definition
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/roleDefinitions"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Role Definition"
+                "Name"   = $roleDefinitionDisplayName
+                "Path"   = "Role Definitions\$($roleDefinition.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$roleDefinitionDisplayName - Failed to restore Role Definition" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreRoleScopeTag.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreRoleScopeTag.ps1
@@ -1,0 +1,69 @@
+function Invoke-IntuneRestoreRoleScopeTag {
+    <#
+    .SYNOPSIS
+    Restore Intune Role Scope Tags
+
+    .DESCRIPTION
+    Restore Intune Role Scope Tags from JSON files per Role Scope Tag from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupRoleScopeTag function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreRoleScopeTag -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementRBAC.ReadWrite.All"
+    }
+
+    # Get all Role Scope Tags
+    $roleScopeTags = Get-ChildItem -Path "$Path\Role Scope Tags" -File -ErrorAction SilentlyContinue
+
+    foreach ($roleScopeTag in $roleScopeTags) {
+        $roleScopeTagContent = Get-Content -LiteralPath $roleScopeTag.FullName -Raw | ConvertFrom-Json
+
+        $roleScopeTagDisplayName = $roleScopeTagContent.displayName
+
+        # Skip the default role scope tags (0 and 1)
+        if ($roleScopeTagContent.id -eq "0" -or $roleScopeTagContent.displayName -eq "Default") {
+            Write-Verbose "Skipping built-in Role Scope Tag: $roleScopeTagDisplayName" -Verbose
+            continue
+        }
+
+        # Remove properties that are not available for creating a new role scope tag
+        $requestBody = $roleScopeTagContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Role Scope Tag
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/roleScopeTags"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Role Scope Tag"
+                "Name"   = $roleScopeTagDisplayName
+                "Path"   = "Role Scope Tags\$($roleScopeTag.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$roleScopeTagDisplayName - Failed to restore Role Scope Tag" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreTargetedManagedAppConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreTargetedManagedAppConfiguration.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreTargetedManagedAppConfiguration {
+    <#
+    .SYNOPSIS
+    Restore Intune Targeted Managed App Configurations
+
+    .DESCRIPTION
+    Restore Intune Targeted Managed App Configurations (app-level MAM) from JSON files per configuration from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupTargetedManagedAppConfiguration function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreTargetedManagedAppConfiguration -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All"
+    }
+
+    # Get all Targeted Managed App Configurations
+    $targetedManagedAppConfigurations = Get-ChildItem -Path "$Path\Targeted Managed App Configurations" -File -ErrorAction SilentlyContinue
+
+    foreach ($targetedManagedAppConfiguration in $targetedManagedAppConfigurations) {
+        $targetedManagedAppConfigurationContent = Get-Content -LiteralPath $targetedManagedAppConfiguration.FullName -Raw | ConvertFrom-Json
+
+        $targetedManagedAppConfigurationDisplayName = $targetedManagedAppConfigurationContent.displayName
+
+        # Remove properties that are not available for creating a new configuration
+        $requestBody = $targetedManagedAppConfigurationContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, version
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Targeted Managed App Configuration
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceAppManagement/targetedManagedAppConfigurations"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Targeted Managed App Configuration"
+                "Name"   = $targetedManagedAppConfigurationDisplayName
+                "Path"   = "Targeted Managed App Configurations\$($targetedManagedAppConfiguration.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$targetedManagedAppConfigurationDisplayName - Failed to restore Targeted Managed App Configuration" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreTermsAndConditions.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreTermsAndConditions.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreTermsAndConditions {
+    <#
+    .SYNOPSIS
+    Restore Intune Terms and Conditions
+
+    .DESCRIPTION
+    Restore Intune Terms and Conditions from JSON files per terms from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupTermsAndConditions function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is v1.0.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreTermsAndConditions -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "v1.0"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementServiceConfig.ReadWrite.All"
+    }
+
+    # Get all Terms and Conditions
+    $termsAndConditions = Get-ChildItem -Path "$Path\Terms and Conditions" -File -ErrorAction SilentlyContinue
+
+    foreach ($terms in $termsAndConditions) {
+        $termsContent = Get-Content -LiteralPath $terms.FullName -Raw | ConvertFrom-Json
+
+        $termsDisplayName = $termsContent.displayName
+
+        # Remove properties that are not available for creating new terms
+        $requestBody = $termsContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, version, acceptanceStatement
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Terms and Conditions
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/termsAndConditions"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Terms and Conditions"
+                "Name"   = $termsDisplayName
+                "Path"   = "Terms and Conditions\$($terms.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$termsDisplayName - Failed to restore Terms and Conditions" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreWindowsDriverUpdateProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreWindowsDriverUpdateProfile.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreWindowsDriverUpdateProfile {
+    <#
+    .SYNOPSIS
+    Restore Intune Windows Driver Update Profiles
+
+    .DESCRIPTION
+    Restore Intune Windows Driver Update Profiles from JSON files per profile from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupWindowsDriverUpdateProfile function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreWindowsDriverUpdateProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Windows Driver Update Profiles
+    $driverUpdateProfiles = Get-ChildItem -Path "$Path\Windows Driver Update Profiles" -File -ErrorAction SilentlyContinue
+
+    foreach ($driverUpdateProfile in $driverUpdateProfiles) {
+        $driverUpdateProfileContent = Get-Content -LiteralPath $driverUpdateProfile.FullName -Raw | ConvertFrom-Json
+
+        $driverUpdateProfileDisplayName = $driverUpdateProfileContent.displayName
+
+        # Remove properties that are not available for creating a new profile
+        $requestBody = $driverUpdateProfileContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Windows Driver Update Profile
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/windowsDriverUpdateProfiles"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Windows Driver Update Profile"
+                "Name"   = $driverUpdateProfileDisplayName
+                "Path"   = "Windows Driver Update Profiles\$($driverUpdateProfile.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$driverUpdateProfileDisplayName - Failed to restore Windows Driver Update Profile" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreWindowsFeatureUpdateProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreWindowsFeatureUpdateProfile.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreWindowsFeatureUpdateProfile {
+    <#
+    .SYNOPSIS
+    Restore Intune Windows Feature Update Profiles
+
+    .DESCRIPTION
+    Restore Intune Windows Feature Update Profiles from JSON files per profile from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupWindowsFeatureUpdateProfile function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreWindowsFeatureUpdateProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Windows Feature Update Profiles
+    $featureUpdateProfiles = Get-ChildItem -Path "$Path\Windows Feature Update Profiles" -File -ErrorAction SilentlyContinue
+
+    foreach ($featureUpdateProfile in $featureUpdateProfiles) {
+        $featureUpdateProfileContent = Get-Content -LiteralPath $featureUpdateProfile.FullName -Raw | ConvertFrom-Json
+
+        $featureUpdateProfileDisplayName = $featureUpdateProfileContent.displayName
+
+        # Remove properties that are not available for creating a new profile
+        $requestBody = $featureUpdateProfileContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime, endOfSupportDate, deployableContentDisplayName
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Windows Feature Update Profile
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/windowsFeatureUpdateProfiles"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Windows Feature Update Profile"
+                "Name"   = $featureUpdateProfileDisplayName
+                "Path"   = "Windows Feature Update Profiles\$($featureUpdateProfile.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$featureUpdateProfileDisplayName - Failed to restore Windows Feature Update Profile" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreWindowsQualityUpdateProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreWindowsQualityUpdateProfile.ps1
@@ -1,0 +1,63 @@
+function Invoke-IntuneRestoreWindowsQualityUpdateProfile {
+    <#
+    .SYNOPSIS
+    Restore Intune Windows Quality Update Profiles
+
+    .DESCRIPTION
+    Restore Intune Windows Quality Update Profiles from JSON files per profile from the specified Path.
+
+    .PARAMETER Path
+    Root path where backup files are located, created with the Invoke-IntuneBackupWindowsQualityUpdateProfile function
+
+    .PARAMETER ApiVersion
+    API version to use (Beta or v1.0). Default is Beta.
+
+    .EXAMPLE
+    Invoke-IntuneRestoreWindowsQualityUpdateProfile -Path "C:\temp"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("v1.0", "Beta")]
+        [string]$ApiVersion = "Beta"
+    )
+
+    #Connect to MS-Graph if required
+    if ($null -eq (Get-MgContext)) {
+        connect-mggraph -scopes "DeviceManagementConfiguration.ReadWrite.All"
+    }
+
+    # Get all Windows Quality Update Profiles
+    $qualityUpdateProfiles = Get-ChildItem -Path "$Path\Windows Quality Update Profiles" -File -ErrorAction SilentlyContinue
+
+    foreach ($qualityUpdateProfile in $qualityUpdateProfiles) {
+        $qualityUpdateProfileContent = Get-Content -LiteralPath $qualityUpdateProfile.FullName -Raw | ConvertFrom-Json
+
+        $qualityUpdateProfileDisplayName = $qualityUpdateProfileContent.displayName
+
+        # Remove properties that are not available for creating a new profile
+        $requestBody = $qualityUpdateProfileContent | Select-Object -Property * -ExcludeProperty id, createdDateTime, lastModifiedDateTime
+
+        $requestBodyJson = $requestBody | ConvertTo-Json -Depth 100
+
+        # Restore the Windows Quality Update Profile
+        try {
+            $createdPolicy = Invoke-MgGraphRequest -Method POST -Body $requestBodyJson.toString() -Uri "$ApiVersion/deviceManagement/windowsQualityUpdateProfiles"
+            [PSCustomObject]@{
+                "Action" = "Restore"
+                "Type"   = "Windows Quality Update Profile"
+                "Name"   = $qualityUpdateProfileDisplayName
+                "Path"   = "Windows Quality Update Profiles\$($qualityUpdateProfile.Name)"
+                "Id"     = $createdPolicy.id
+            }
+        }
+        catch {
+            Write-Verbose "$qualityUpdateProfileDisplayName - Failed to restore Windows Quality Update Profile" -Verbose
+            Write-Error $_ -ErrorAction Continue
+        }
+    }
+}

--- a/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
@@ -33,7 +33,7 @@ function Start-IntuneBackup() {
 
     #Connect to MS-Graph if required
     if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementScripts.ReadWrite.All" 
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementRBAC.ReadWrite.All, DeviceManagementScripts.ReadWrite.All, Policy.Read.All, Policy.ReadWrite.ConditionalAccess"
     }else{
         Write-Host "MS-Graph already connected, checking scopes"
         $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
@@ -41,7 +41,11 @@ function Start-IntuneBackup() {
             "DeviceManagementApps.ReadWrite.All",
             "DeviceManagementConfiguration.ReadWrite.All",
             "DeviceManagementServiceConfig.ReadWrite.All",
-            "DeviceManagementManagedDevices.ReadWrite.All"
+            "DeviceManagementManagedDevices.ReadWrite.All",
+            "DeviceManagementRBAC.ReadWrite.All",
+            "DeviceManagementScripts.ReadWrite.All",
+            "Policy.Read.All",
+            "Policy.ReadWrite.ConditionalAccess"
         )
         # Use case-insensitive comparison
         $missingScopes = $requiredScopes | Where-Object {
@@ -51,7 +55,7 @@ function Start-IntuneBackup() {
 
         if ($missingScopes) {
             Write-Error "Missing required permission scopes: $($missingScopes -join ', ')"
-            Write-Error "Please reconnect with the correct permissions using: Connect-MgGraph -Scopes 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementScripts.ReadWrite.All'"
+            Write-Error "Please reconnect with the correct permissions using: Connect-MgGraph -Scopes 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementRBAC.ReadWrite.All, DeviceManagementScripts.ReadWrite.All, Policy.Read.All, Policy.ReadWrite.ConditionalAccess'"
             throw "Insufficient permissions. Backup cannot continue."
         }else{
             Write-Host "MS-Graph scopes are correct"
@@ -59,22 +63,55 @@ function Start-IntuneBackup() {
 		Write-Host ""
     }
 
-    Invoke-IntuneBackupAutopilotDeploymentProfile -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupAutopilotDeploymentProfileAssignment -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupClientApp -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupClientAppAssignment -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupConfigurationPolicy -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupConfigurationPolicyAssignment -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceCompliancePolicy -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceCompliancePolicyAssignment -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceConfiguration -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceConfigurationAssignment -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceHealthScript -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceHealthScriptAssignment -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceManagementScript -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceManagementScriptAssignment -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupGroupPolicyConfiguration -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupGroupPolicyConfigurationAssignment -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupDeviceManagementIntent -Path $Path -ErrorAction Continue
-    Invoke-IntuneBackupAppProtectionPolicy -Path $Path -ErrorAction Continue
+    # Backup dependencies first (needed by other policies)
+    try { Invoke-IntuneBackupRoleScopeTag -Path $Path } catch { Write-Warning "Failed to backup Role Scope Tags: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupAssignmentFilter -Path $Path } catch { Write-Warning "Failed to backup Assignment Filters: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupNamedLocation -Path $Path } catch { Write-Warning "Failed to backup Named Locations: $($_.Exception.Message)" }
+
+    # Backup enrollment configurations
+    try { Invoke-IntuneBackupDeviceEnrollmentConfiguration -Path $Path } catch { Write-Warning "Failed to backup Device Enrollment Configurations: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupAutopilotDeploymentProfile -Path $Path } catch { Write-Warning "Failed to backup Autopilot Deployment Profiles: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupAutopilotDeploymentProfileAssignment -Path $Path } catch { Write-Warning "Failed to backup Autopilot Deployment Profile Assignments: $($_.Exception.Message)" }
+
+    # Backup device configurations
+    try { Invoke-IntuneBackupConfigurationPolicy -Path $Path } catch { Write-Warning "Failed to backup Configuration Policies: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupConfigurationPolicyAssignment -Path $Path } catch { Write-Warning "Failed to backup Configuration Policy Assignments: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupDeviceConfiguration -Path $Path } catch { Write-Warning "Failed to backup Device Configurations: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupDeviceConfigurationAssignment -Path $Path } catch { Write-Warning "Failed to backup Device Configuration Assignments: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupGroupPolicyConfiguration -Path $Path } catch { Write-Warning "Failed to backup Group Policy Configurations: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupGroupPolicyConfigurationAssignment -Path $Path } catch { Write-Warning "Failed to backup Group Policy Configuration Assignments: $($_.Exception.Message)" }
+
+    # Backup compliance policies
+    try { Invoke-IntuneBackupDeviceCompliancePolicy -Path $Path } catch { Write-Warning "Failed to backup Device Compliance Policies: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupDeviceCompliancePolicyAssignment -Path $Path } catch { Write-Warning "Failed to backup Device Compliance Policy Assignments: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupDeviceManagementIntent -Path $Path } catch { Write-Warning "Failed to backup Device Management Intents: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupDeviceManagementIntentAssignment -Path $Path } catch { Write-Warning "Failed to backup Device Management Intent Assignments: $($_.Exception.Message)" }
+
+    # Backup Windows Update profiles
+    try { Invoke-IntuneBackupWindowsFeatureUpdateProfile -Path $Path } catch { Write-Warning "Failed to backup Windows Feature Update Profiles: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupWindowsQualityUpdateProfile -Path $Path } catch { Write-Warning "Failed to backup Windows Quality Update Profiles: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupWindowsDriverUpdateProfile -Path $Path } catch { Write-Warning "Failed to backup Windows Driver Update Profiles: $($_.Exception.Message)" }
+
+    # Backup applications and app configurations
+    try { Invoke-IntuneBackupClientApp -Path $Path } catch { Write-Warning "Failed to backup Client Apps: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupClientAppAssignment -Path $Path } catch { Write-Warning "Failed to backup Client App Assignments: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupAppProtectionPolicy -Path $Path } catch { Write-Warning "Failed to backup App Protection Policies: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupMobileAppConfiguration -Path $Path } catch { Write-Warning "Failed to backup Mobile App Configurations: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupTargetedManagedAppConfiguration -Path $Path } catch { Write-Warning "Failed to backup Targeted Managed App Configurations: $($_.Exception.Message)" }
+
+    # Backup scripts
+    try { Invoke-IntuneBackupDeviceHealthScript -Path $Path } catch { Write-Warning "Failed to backup Device Health Scripts: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupDeviceHealthScriptAssignment -Path $Path } catch { Write-Warning "Failed to backup Device Health Script Assignments: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupDeviceManagementScript -Path $Path } catch { Write-Warning "Failed to backup Device Management Scripts: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupDeviceManagementScriptAssignment -Path $Path } catch { Write-Warning "Failed to backup Device Management Script Assignments: $($_.Exception.Message)" }
+
+    # Backup Conditional Access
+    try { Invoke-IntuneBackupConditionalAccessPolicy -Path $Path } catch { Write-Warning "Failed to backup Conditional Access Policies: $($_.Exception.Message)" }
+
+    # Backup administrative and branding
+    try { Invoke-IntuneBackupRoleDefinition -Path $Path } catch { Write-Warning "Failed to backup Role Definitions: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupNotificationTemplate -Path $Path } catch { Write-Warning "Failed to backup Notification Templates: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupTermsAndConditions -Path $Path } catch { Write-Warning "Failed to backup Terms and Conditions: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupIntuneBrandingProfile -Path $Path } catch { Write-Warning "Failed to backup Intune Branding Profiles: $($_.Exception.Message)" }
+    try { Invoke-IntuneBackupPolicySet -Path $Path } catch { Write-Warning "Failed to backup Policy Sets: $($_.Exception.Message)" }
 }

--- a/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
@@ -33,42 +33,48 @@ function Start-IntuneBackup() {
 
     #Connect to MS-Graph if required
     if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "EntitlementManagement.ReadWrite.All, DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementScripts.ReadWrite.All" 
     }else{
         Write-Host "MS-Graph already connected, checking scopes"
         $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
-        $IncorrectScopes = $false
-        if ($scopes -notcontains "DeviceManagementApps.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementConfiguration.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementServiceConfig.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementManagedDevices.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($IncorrectScopes) {
-            Write-Host "Incorrect scopes, please sign in again"
-            connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
+        $requiredScopes = @(
+            "DeviceManagementApps.ReadWrite.All",
+            "DeviceManagementConfiguration.ReadWrite.All",
+            "DeviceManagementServiceConfig.ReadWrite.All",
+            "DeviceManagementManagedDevices.ReadWrite.All"
+        )
+        # Use case-insensitive comparison
+        $missingScopes = $requiredScopes | Where-Object {
+            $requiredScope = $_
+            -not ($scopes | Where-Object { $_ -eq $requiredScope })
+        }
+
+        if ($missingScopes) {
+            Write-Error "Missing required permission scopes: $($missingScopes -join ', ')"
+            Write-Error "Please reconnect with the correct permissions using: Connect-MgGraph -Scopes 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementScripts.ReadWrite.All'"
+            throw "Insufficient permissions. Backup cannot continue."
         }else{
             Write-Host "MS-Graph scopes are correct"
         }
 		Write-Host ""
     }
 
-    Invoke-IntuneBackupAutopilotDeploymentProfile -Path $Path
-    Invoke-IntuneBackupAutopilotDeploymentProfileAssignment -Path $Path
-    Invoke-IntuneBackupClientApp -Path $Path
-    Invoke-IntuneBackupClientAppAssignment -Path $Path
-    Invoke-IntuneBackupConfigurationPolicy -Path $Path
-    Invoke-IntuneBackupConfigurationPolicyAssignment -Path $Path
-    Invoke-IntuneBackupDeviceCompliancePolicy -Path $Path
-    Invoke-IntuneBackupDeviceCompliancePolicyAssignment -Path $Path
-    Invoke-IntuneBackupDeviceConfiguration -Path $Path
-    Invoke-IntuneBackupDeviceConfigurationAssignment -Path $Path
-    Invoke-IntuneBackupDeviceHealthScript -Path $Path
-    Invoke-IntuneBackupDeviceHealthScriptAssignment -Path $Path
-    Invoke-IntuneBackupDeviceManagementScript -Path $Path
-    Invoke-IntuneBackupDeviceManagementScriptAssignment -Path $Path
-    Invoke-IntuneBackupGroupPolicyConfiguration -Path $Path
-    Invoke-IntuneBackupGroupPolicyConfigurationAssignment -Path $Path
-    Invoke-IntuneBackupDeviceManagementIntent -Path $Path
-    Invoke-IntuneBackupAppProtectionPolicy -Path $Path
-    Invoke-IntuneBackupDeviceHealthScript -Path $Path
-    Invoke-IntuneBackupDeviceHealthScriptAssignment -Path $Path
+    Invoke-IntuneBackupAutopilotDeploymentProfile -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupAutopilotDeploymentProfileAssignment -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupClientApp -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupClientAppAssignment -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupConfigurationPolicy -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupConfigurationPolicyAssignment -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceCompliancePolicy -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceCompliancePolicyAssignment -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceConfiguration -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceConfigurationAssignment -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceHealthScript -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceHealthScriptAssignment -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceManagementScript -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceManagementScriptAssignment -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupGroupPolicyConfiguration -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupGroupPolicyConfigurationAssignment -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupDeviceManagementIntent -Path $Path -ErrorAction Continue
+    Invoke-IntuneBackupAppProtectionPolicy -Path $Path -ErrorAction Continue
 }

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreAssignments.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreAssignments.ps1
@@ -38,31 +38,39 @@ function Start-IntuneRestoreAssignments() {
 
     #Connect to MS-Graph if required
     if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "EntitlementManagement.ReadWrite.All, DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementScripts.ReadWrite.All" 
     }else{
         Write-Host "MS-Graph already connected, checking scopes"
         $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
-        $IncorrectScopes = $false
-        if ($scopes -notcontains "DeviceManagementApps.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementConfiguration.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementServiceConfig.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementManagedDevices.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($IncorrectScopes) {
-            Write-Host "Incorrect scopes, please sign in again"
-            connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
-        }else{
-            Write-Host "MS-Graph scopes are correct"     
+        $requiredScopes = @(
+            "DeviceManagementApps.ReadWrite.All",
+            "DeviceManagementConfiguration.ReadWrite.All",
+            "DeviceManagementServiceConfig.ReadWrite.All",
+            "DeviceManagementManagedDevices.ReadWrite.All"
+        )
+        # Use case-insensitive comparison
+        $missingScopes = $requiredScopes | Where-Object {
+            $requiredScope = $_
+            -not ($scopes | Where-Object { $_ -eq $requiredScope })
         }
-  
+
+        if ($missingScopes) {
+            Write-Error "Missing required permission scopes: $($missingScopes -join ', ')"
+            Write-Error "Please reconnect with the correct permissions using: Connect-MgGraph -Scopes 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All'"
+            throw "Insufficient permissions. Restore assignments cannot continue."
+        }else{
+            Write-Host "MS-Graph scopes are correct"
+        }
+
     }
 
-    Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment -Path $path -RestoreById $restoreById
-    Invoke-IntuneRestoreConfigurationPolicyAssignment -Path $path -RestoreById $restoreById
-    Invoke-IntuneRestoreClientAppAssignment -Path $path -RestoreById $restoreById
-    Invoke-IntuneRestoreDeviceCompliancePolicyAssignment -Path $path -RestoreById $restoreById
-    Invoke-IntuneRestoreDeviceConfigurationAssignment -Path $path -RestoreById $restoreById
-    Invoke-IntuneRestoreDeviceHealthScriptAssignment -Path $Path -RestoreById $restoreById
-    Invoke-IntuneRestoreDeviceManagementScriptAssignment -Path $path -RestoreById $restoreById
-    Invoke-IntuneRestoreGroupPolicyConfigurationAssignment -Path $path -RestoreById $restoreById
-	
+    Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment -Path $path -RestoreById $restoreById -ErrorAction Continue
+    Invoke-IntuneRestoreConfigurationPolicyAssignment -Path $path -RestoreById $restoreById -ErrorAction Continue
+    Invoke-IntuneRestoreClientAppAssignment -Path $path -RestoreById $restoreById -ErrorAction Continue
+    Invoke-IntuneRestoreDeviceCompliancePolicyAssignment -Path $path -RestoreById $restoreById -ErrorAction Continue
+    Invoke-IntuneRestoreDeviceConfigurationAssignment -Path $path -RestoreById $restoreById -ErrorAction Continue
+    Invoke-IntuneRestoreDeviceHealthScriptAssignment -Path $Path -RestoreById $restoreById -ErrorAction Continue
+    Invoke-IntuneRestoreDeviceManagementScriptAssignment -Path $path -RestoreById $restoreById -ErrorAction Continue
+    Invoke-IntuneRestoreGroupPolicyConfigurationAssignment -Path $path -RestoreById $restoreById -ErrorAction Continue
+
 }

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
@@ -33,7 +33,7 @@ function Start-IntuneRestoreConfig() {
 
     #Connect to MS-Graph if required
     if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementScripts.ReadWrite.All" 
+        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementRBAC.ReadWrite.All, DeviceManagementScripts.ReadWrite.All, Policy.Read.All, Policy.ReadWrite.ConditionalAccess"
     }else{
         Write-Host "MS-Graph already connected, checking scopes"
         $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
@@ -41,7 +41,11 @@ function Start-IntuneRestoreConfig() {
             "DeviceManagementApps.ReadWrite.All",
             "DeviceManagementConfiguration.ReadWrite.All",
             "DeviceManagementServiceConfig.ReadWrite.All",
-            "DeviceManagementManagedDevices.ReadWrite.All"
+            "DeviceManagementManagedDevices.ReadWrite.All",
+            "DeviceManagementRBAC.ReadWrite.All",
+            "DeviceManagementScripts.ReadWrite.All",
+            "Policy.Read.All",
+            "Policy.ReadWrite.ConditionalAccess"
         )
         # Use case-insensitive comparison
         $missingScopes = $requiredScopes | Where-Object {
@@ -51,7 +55,7 @@ function Start-IntuneRestoreConfig() {
 
         if ($missingScopes) {
             Write-Error "Missing required permission scopes: $($missingScopes -join ', ')"
-            Write-Error "Please reconnect with the correct permissions using: Connect-MgGraph -Scopes 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All'"
+            Write-Error "Please reconnect with the correct permissions using: Connect-MgGraph -Scopes 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementRBAC.ReadWrite.All, DeviceManagementScripts.ReadWrite.All, Policy.Read.All, Policy.ReadWrite.ConditionalAccess'"
             throw "Insufficient permissions. Restore cannot continue."
         }else{
             Write-Host "MS-Graph scopes are correct"
@@ -59,13 +63,45 @@ function Start-IntuneRestoreConfig() {
 
     }
 
-    Invoke-IntuneRestoreAutopilotDeploymentProfile -Path $Path -ErrorAction Continue
-    Invoke-IntuneRestoreConfigurationPolicy -Path $Path -ErrorAction Continue
-    Invoke-IntuneRestoreDeviceCompliancePolicy -Path $Path -ErrorAction Continue
-    Invoke-IntuneRestoreDeviceConfiguration -Path $Path -ErrorAction Continue
-    Invoke-IntuneRestoreDeviceHealthScript -Path $Path -ErrorAction Continue
-    Invoke-IntuneRestoreDeviceManagementScript -Path $Path -ErrorAction Continue
-    Invoke-IntuneRestoreGroupPolicyConfiguration -Path $Path -ErrorAction Continue
-    Invoke-IntuneRestoreDeviceManagementIntent -Path $Path -ErrorAction Continue
-    Invoke-IntuneRestoreAppProtectionPolicy -Path $Path -ErrorAction Continue
+    # Restore dependencies first (needed by other policies)
+    try { Invoke-IntuneRestoreRoleScopeTag -Path $Path } catch { Write-Warning "Failed to restore Role Scope Tags: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreAssignmentFilter -Path $Path } catch { Write-Warning "Failed to restore Assignment Filters: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreNamedLocation -Path $Path } catch { Write-Warning "Failed to restore Named Locations: $($_.Exception.Message)" }
+
+    # Restore enrollment configurations
+    try { Invoke-IntuneRestoreDeviceEnrollmentConfiguration -Path $Path } catch { Write-Warning "Failed to restore Device Enrollment Configurations: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreAutopilotDeploymentProfile -Path $Path } catch { Write-Warning "Failed to restore Autopilot Deployment Profiles: $($_.Exception.Message)" }
+
+    # Restore device configurations
+    try { Invoke-IntuneRestoreConfigurationPolicy -Path $Path } catch { Write-Warning "Failed to restore Configuration Policies: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreDeviceConfiguration -Path $Path } catch { Write-Warning "Failed to restore Device Configurations: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreGroupPolicyConfiguration -Path $Path } catch { Write-Warning "Failed to restore Group Policy Configurations: $($_.Exception.Message)" }
+
+    # Restore compliance policies
+    try { Invoke-IntuneRestoreDeviceCompliancePolicy -Path $Path } catch { Write-Warning "Failed to restore Device Compliance Policies: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreDeviceManagementIntent -Path $Path } catch { Write-Warning "Failed to restore Device Management Intents: $($_.Exception.Message)" }
+
+    # Restore Windows Update profiles
+    try { Invoke-IntuneRestoreWindowsFeatureUpdateProfile -Path $Path } catch { Write-Warning "Failed to restore Windows Feature Update Profiles: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreWindowsQualityUpdateProfile -Path $Path } catch { Write-Warning "Failed to restore Windows Quality Update Profiles: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreWindowsDriverUpdateProfile -Path $Path } catch { Write-Warning "Failed to restore Windows Driver Update Profiles: $($_.Exception.Message)" }
+
+    # Restore applications and app configurations
+    try { Invoke-IntuneRestoreAppProtectionPolicy -Path $Path } catch { Write-Warning "Failed to restore App Protection Policies: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreMobileAppConfiguration -Path $Path } catch { Write-Warning "Failed to restore Mobile App Configurations: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreTargetedManagedAppConfiguration -Path $Path } catch { Write-Warning "Failed to restore Targeted Managed App Configurations: $($_.Exception.Message)" }
+
+    # Restore scripts
+    try { Invoke-IntuneRestoreDeviceHealthScript -Path $Path } catch { Write-Warning "Failed to restore Device Health Scripts: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreDeviceManagementScript -Path $Path } catch { Write-Warning "Failed to restore Device Management Scripts: $($_.Exception.Message)" }
+
+    # Restore Conditional Access
+    try { Invoke-IntuneRestoreConditionalAccessPolicy -Path $Path } catch { Write-Warning "Failed to restore Conditional Access Policies: $($_.Exception.Message)" }
+
+    # Restore administrative and branding
+    try { Invoke-IntuneRestoreRoleDefinition -Path $Path } catch { Write-Warning "Failed to restore Role Definitions: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreNotificationTemplate -Path $Path } catch { Write-Warning "Failed to restore Notification Templates: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreTermsAndConditions -Path $Path } catch { Write-Warning "Failed to restore Terms and Conditions: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestoreIntuneBrandingProfile -Path $Path } catch { Write-Warning "Failed to restore Intune Branding Profiles: $($_.Exception.Message)" }
+    try { Invoke-IntuneRestorePolicySet -Path $Path } catch { Write-Warning "Failed to restore Policy Sets: $($_.Exception.Message)" }
 }

--- a/README.md
+++ b/README.md
@@ -265,6 +265,15 @@ This module is ideal for:
 
 ## Version History
 
+### Version 5.1.0 (2025-12-05)
+- **Fixed Policy Set backup** to handle API limitation where $expand is not supported on collection queries
+- **Fixed Device Enrollment Configuration restore** to use Beta API, include deviceEnrollmentConfigurationType, handle priority conflicts with auto-increment, and cast priority values to [int]
+- **Fixed Notification Template restore** with two-step process (create template, then add localized messages) and proper property handling
+- **Fixed Conditional Access and Named Location restore** to use Beta API and require Policy.ReadWrite.ConditionalAccess scope
+- **Updated scope validation** in Start-IntuneBackup and Start-IntuneRestoreConfig to include all 8 required scopes
+- **Enhanced verbose logging** throughout restore functions for better debugging
+- **Improved error handling** to continue operations when individual policy types fail
+
 ### Version 5.0.0 (2025-12-01)
 - **Added 17 new backup policy types:** Assignment Filters, Role Scope Tags, Device Enrollment Configurations, Named Locations, Conditional Access, Windows Update Profiles, App Configurations, Notification Templates, Branding, Terms & Conditions, Role Definitions, Policy Sets, and more
 - **Added 15 new restore functions** for all new backup types


### PR DESCRIPTION
## [5.1.0] - 2025-12-05
- Fixed `Invoke-IntuneBackupPolicySet` to handle API limitation where $expand is not supported on collection queries. Now queries each policy set individually with expand.
- Fixed `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` to use Beta API endpoint (required by Microsoft Graph).
- Fixed `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` priority conflict handling with automatic priority increment.
- Fixed `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` to correctly include `deviceEnrollmentConfigurationType` property.
- Fixed `Invoke-IntuneRestoreDeviceEnrollmentConfiguration` to add [int] casting for priority values to prevent type conversion errors.
- Fixed `Invoke-IntuneRestoreNotificationTemplate` to use two-step process: create template first, then add localized messages separately.
- Fixed `Invoke-IntuneRestoreNotificationTemplate` to remove `defaultLocale` and `description` properties during creation (causes BadRequest errors).
- Fixed `Invoke-IntuneBackupConfigurationPolicyAssignment` to use pagination so more than 25 assignments are returned.
- Fixed `Invoke-IntuneRestoreConditionalAccessPolicy` and `Invoke-IntuneRestoreNamedLocation` to use Beta API and require Policy.ReadWrite.ConditionalAccess scope.
- Fixed scope validation in `Start-IntuneBackup` and `Start-IntuneRestoreConfig` to include all 8 required scopes including Policy.ReadWrite.ConditionalAccess.
- Added comprehensive verbose logging throughout restore functions for debugging.
- Updated `Start-IntuneBackup` scope validation from 4 scopes to 8 scopes (added DeviceManagementScripts, Policy.Read.All, Policy.ReadWrite.ConditionalAccess).
- Updated `Start-IntuneRestoreConfig` scope validation to match backup requirements.
- Improved error handling to continue restore operations even when individual policy types fail.

## [5.0.0] - 2025-12-01
- Added function `Invoke-IntuneBackupAssignmentFilter`.
- Added function `Invoke-IntuneRestoreAssignmentFilter`.
- Added function `Invoke-IntuneBackupRoleScopeTag`.
- Added function `Invoke-IntuneRestoreRoleScopeTag`.
- Added function `Invoke-IntuneBackupDeviceEnrollmentConfiguration`.
- Added function `Invoke-IntuneRestoreDeviceEnrollmentConfiguration`.
- Added function `Invoke-IntuneBackupNamedLocation`.
- Added function `Invoke-IntuneRestoreNamedLocation`.
- Added function `Invoke-IntuneBackupConditionalAccessPolicy`.
- Added function `Invoke-IntuneRestoreConditionalAccessPolicy`.
- Added function `Invoke-IntuneBackupWindowsFeatureUpdateProfile`.
- Added function `Invoke-IntuneRestoreWindowsFeatureUpdateProfile`.
- Added function `Invoke-IntuneBackupWindowsQualityUpdateProfile`.
- Added function `Invoke-IntuneRestoreWindowsQualityUpdateProfile`.
- Added function `Invoke-IntuneBackupWindowsDriverUpdateProfile`.
- Added function `Invoke-IntuneRestoreWindowsDriverUpdateProfile`.
- Added function `Invoke-IntuneBackupMobileAppConfiguration`.
- Added function `Invoke-IntuneRestoreMobileAppConfiguration`.
- Added function `Invoke-IntuneBackupTargetedManagedAppConfiguration`.
- Added function `Invoke-IntuneRestoreTargetedManagedAppConfiguration`.
- Added function `Invoke-IntuneBackupNotificationTemplate`.
- Added function `Invoke-IntuneRestoreNotificationTemplate`.
- Added function `Invoke-IntuneBackupIntuneBrandingProfile`.
- Added function `Invoke-IntuneRestoreIntuneBrandingProfile`.
- Added function `Invoke-IntuneBackupTermsAndConditions`.
- Added function `Invoke-IntuneRestoreTermsAndConditions`.
- Added function `Invoke-IntuneBackupRoleDefinition`.
- Added function `Invoke-IntuneRestoreRoleDefinition`.
- Added function `Invoke-IntuneBackupPolicySet`.
- Added function `Invoke-IntuneRestorePolicySet`.
- Added function `Invoke-IntuneBackupDeviceManagementIntentAssignment`.
- Embedded all new backup functions in the `Start-IntuneBackup` cmdlet.
- Embedded all new restore functions in the `Start-IntuneRestoreConfig` cmdlet.
- Updated `Start-IntuneBackup` and `Start-IntuneRestoreConfig` with try-catch error handling for all function calls.
- Updated required permissions to include `DeviceManagementRBAC.ReadWrite.All` and `Policy.Read.All`.
- Fixed issue where Graph API terminating errors would stop the entire backup/restore process.
- Backup and restore operations now continue even if individual policy types fail due to permissions or API errors.