### PR TITLE
Update MS Graph Connection Handling

### DIFF
--- a/IntuneBackupAndRestore/Private/Test-GraphConnection.ps1
+++ b/IntuneBackupAndRestore/Private/Test-GraphConnection.ps1
@@ -1,0 +1,51 @@
+﻿function Test-GraphConnection {
+    <#
+    .SYNOPSIS
+	Tests the connection to Microsoft Graph.
+
+    .DESCRIPTION
+	Checks that a connection is already established with Microsoft Graph (using Connect-MgGraph from the Microsoft Graph PowerShell SDK) and that the required scopes are included in the connection.
+	If no connection is established, or if the required scopes are not included, it will prompt the user to connect to Microsoft Graph with the correct scopes.
+
+    .PARAMETER RequiredScopes
+	An array of the required scopes for the current operation.
+
+	.PARAMETER CheckScopes
+	Switch parameter, indicating whether the current operation requires first checking that the required scopes are active in the current connection.
+
+    .EXAMPLE
+	PS C:\> Test-GraphConnection -RequiredScopes "DeviceManagementApps.ReadWrite.All", "DeviceManagementConfiguration.ReadWrite.All"
+
+	First checks if there is already a connection established with Microsoft Graph, and if not then initializes the connection with the listed scopes.
+
+    .EXAMPLE
+	PS C:\> Test-GraphConnection -RequiredScopes "DeviceManagementApps.ReadWrite.All", "DeviceManagementConfiguration.ReadWrite.All" -CheckScopes
+
+	First checks if there is already a connection established with Microsoft Graph.
+	If there isn't a connection, then it initializes the connection process with the listed scopes.
+	If there *is* a connection already present, then it will check that the listed scopes are active, and re-run the connection process if there is one or more missing.
+    #>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory)]
+		[string[]]$RequiredScopes,
+
+		[switch]$CheckScopes
+	)
+
+    if ($null -eq (Get-MgContext)) {
+        Connect-MgGraph -scopes $RequiredScopes
+    } elseif ($CheckScopes) {
+        Write-Host "MS-Graph already connected, checking scopes"
+        $currentScopes = Get-MgContext | Select-Object -ExpandProperty Scopes
+		$missingScopes = Compare-Object -ReferenceObject $RequiredScopes -DifferenceObject $currentScopes |
+			Where-Object { $_.SideIndicator -eq '<=' }
+		if ($missingScopes) {
+            Write-Host "Incorrect scopes, please sign in again"
+            Connect-MgGraph -scopes $RequiredScopes
+		} else {
+			Write-Host "MS-Graph scopes are correct"
+		}
+		Write-Host ""
+    }
+}

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicy.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupAppProtectionPolicy {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicy.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupAppProtectionPolicy {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all App Protection Policies
     $appProtectionPolicies = Invoke-MgGraphRequest -Uri "/$ApiVersion/deviceAppManagement/managedAppPolicies" | Get-MgGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicyAssignment.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupAppProtectionPolicyAssignment {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     $appProtectionPolicies = Invoke-MgGraphRequest -Uri "/$ApiVersion/deviceAppManagement/managedAppPolicies" | Get-MgGraphAllPages
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAppProtectionPolicyAssignment.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupAppProtectionPolicyAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfile.ps1
@@ -28,7 +28,7 @@
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupAutopilotDeploymentProfile.ps1
@@ -24,10 +24,14 @@
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
-	
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
+
 	# Get all Autopilot Deployment Profiles
     $winAutopilotDeploymentProfiles = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/$ApiVersion/deviceManagement/windowsAutopilotDeploymentProfiles" -OutputType PSObject | Select-Object -ExpandProperty Value
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientApp.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientApp.ps1
@@ -22,11 +22,15 @@ function Invoke-IntuneBackupClientApp {
         [ValidateSet("v1.0", "Beta")]
         [string]$ApiVersion = "Beta"
     )
-    
+
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all Client Apps
     $filter = "microsoft.graph.managedApp/appAvailability eq null or microsoft.graph.managedApp/appAvailability eq 'lineOfBusiness' or isAssigned eq true"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientApp.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientApp.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupClientApp {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientAppAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientAppAssignment.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupClientAppAssignment {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
      # Get all Client Apps
      $filter = "microsoft.graph.managedApp/appAvailability eq null or microsoft.graph.managedApp/appAvailability eq 'lineOfBusiness' or isAssigned eq true"

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientAppAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupClientAppAssignment.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupClientAppAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicy.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupConfigurationPolicy {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all Setting Catalogs Policies
     $configurationPolicies = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/configurationPolicies" | Get-MGGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicy.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupConfigurationPolicy {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicyAssignment.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupConfigurationPolicyAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupConfigurationPolicyAssignment.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupConfigurationPolicyAssignment {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all assignments from all policies
     $configurationPolicies = (Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/configurationPolicies").value

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceCompliancePolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceCompliancePolicy.ps1
@@ -24,9 +24,12 @@ function Invoke-IntuneBackupDeviceCompliancePolicy {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all Device Compliance Policies
     $deviceCompliancePolicies = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceCompliancePolicies" | Get-MGGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceCompliancePolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceCompliancePolicyAssignment.ps1
@@ -24,9 +24,12 @@ function Invoke-IntuneBackupDeviceCompliancePolicyAssignment {
     )
 
      #Connect to MS-Graph if required
-     if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All" 
-    }
+     $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all Device Compliance Policies
     $deviceCompliancePolicies = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceCompliancePolicies" | Get-MGGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupDeviceConfiguration {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfiguration.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupDeviceConfiguration {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all device configurations
     $deviceConfigurations = Invoke-MgGraphRequest -Uri "$apiVersion/deviceManagement/deviceConfigurations" | Get-MGGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfigurationAssignment.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupDeviceConfigurationAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceConfigurationAssignment.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupDeviceConfigurationAssignment {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all assignments from all policies
     $deviceConfigurations = Invoke-MgGraphRequest -Uri "$apiVersion/deviceManagement/deviceConfigurations" | Get-MGGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
@@ -27,7 +27,7 @@
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScript.ps1
@@ -23,9 +23,13 @@
     )
     
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
 	# Get all Intune Health Scripts
     $healthScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceHealthScripts" | Get-MGGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
@@ -23,10 +23,14 @@
         [string]$ApiVersion = "Beta"
     )
 
-     #Connect to MS-Graph if required
-     if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+	#Connect to MS-Graph if required
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all assignments from all policies
     $healthScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceHealthScripts" | Get-MGGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceHealthScriptAssignment.ps1
@@ -28,7 +28,7 @@
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntent.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupDeviceManagementIntent {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     Write-Verbose "Requesting Intents"
     $intents = Get-MgBetaDeviceManagementIntent -all

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementIntent.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupDeviceManagementIntent {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScript.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupDeviceManagementScript {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScript.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupDeviceManagementScript {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all device management scripts
     $deviceManagementScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceManagementScripts" | Get-MgGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScriptAssignment.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupDeviceManagementScriptAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupDeviceManagementScriptAssignment.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneBackupDeviceManagementScriptAssignment {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all assignments from all policies
     $deviceManagementScripts = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/deviceManagementScripts" | Get-MgGraphAllPages

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfiguration.ps1
@@ -24,10 +24,14 @@ function Invoke-IntuneBackupGroupPolicyConfiguration {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
-    
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
+
 	# Get all Group Policy Configurations
     $groupPolicyConfigurations = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/groupPolicyConfigurations" | Get-MgGraphAllPages
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfiguration.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupGroupPolicyConfiguration {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfigurationAssignment.ps1
@@ -24,10 +24,14 @@ function Invoke-IntuneBackupGroupPolicyConfigurationAssignment {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
-    
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
+
     # Get all assignments from all policies
     $groupPolicyConfigurations = Invoke-MgGraphRequest -Uri "$ApiVersion/deviceManagement/groupPolicyConfigurations" | Get-MgGraphAllPages
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneBackupGroupPolicyConfigurationAssignment.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneBackupGroupPolicyConfigurationAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
@@ -23,13 +23,17 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all App Protection Policies
     $appProtectionPolicies = Get-ChildItem -Path "$path\App Protection Policies" -File -ErrorAction SilentlyContinue
-    
+
     foreach ($appProtectionPolicy in $appProtectionPolicies) {
         $appProtectionPolicyContent = Get-Content -LiteralPath $appProtectionPolicy.FullName | convertfrom-json
         $appProtectionPolicyDisplayName = $appProtectionPolicyContent.displayName

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicy.ps1
@@ -27,7 +27,7 @@ function Invoke-IntuneRestoreAppProtectionPolicy {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicyAssignment.ps1
@@ -35,7 +35,7 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAppProtectionPolicyAssignment.ps1
@@ -31,9 +31,13 @@ function Invoke-IntuneRestoreAppProtectionPolicyAssignment {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all policies with assignments
     $appProtectionPolicies = Get-ChildItem -Path "$Path\App Protection Policies\Assignments" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfile.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneRestoreAutopilotDeploymentProfile {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        Connect-MgGraph -Scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all device health scripts
     $winAutopilotDeploymentProfiles = Get-ChildItem -Path "$Path\Autopilot Deployment Profiles" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfile.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreAutopilotDeploymentProfile.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneRestoreAutopilotDeploymentProfile {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreClientAppAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreClientAppAssignment.ps1
@@ -31,8 +31,13 @@ function Invoke-IntuneRestoreClientAppAssignment {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
     }
 
     # Get all policies with assignments

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreClientAppAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreClientAppAssignment.ps1
@@ -35,7 +35,7 @@ function Invoke-IntuneRestoreClientAppAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
     }

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicy.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneRestoreConfigurationPolicy {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicy.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneRestoreConfigurationPolicy {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all Settings Catalog Policies
     $configurationPolicies = Get-ChildItem -Path "$Path\Settings Catalog" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicyAssignment.ps1
@@ -36,7 +36,7 @@ function Invoke-IntuneRestoreConfigurationPolicyAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreConfigurationPolicyAssignment.ps1
@@ -32,9 +32,13 @@ function Invoke-IntuneRestoreConfigurationPolicyAssignment {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all policies with assignments
     $configurationPolicies = Get-ChildItem -Path "$Path\Settings Catalog\Assignments" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicy.ps1
@@ -24,9 +24,12 @@ function Invoke-IntuneRestoreDeviceCompliancePolicy {
     )
 
      #Connect to MS-Graph if required
-     if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all Device Compliance Policies
     $deviceCompliancePolicies = Get-ChildItem -Path "$Path\Device Compliance Policies" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicyAssignment.ps1
@@ -32,9 +32,13 @@ function Invoke-IntuneRestoreDeviceCompliancePolicyAssignment {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all policies with assignments
     $deviceCompliancePolicies = Get-ChildItem -Path "$Path\Device Compliance Policies\Assignments" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicyAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceCompliancePolicyAssignment.ps1
@@ -36,7 +36,7 @@ function Invoke-IntuneRestoreDeviceCompliancePolicyAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneRestoreDeviceConfiguration {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfiguration.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneRestoreDeviceConfiguration {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all device configurations
     $deviceConfigurations = Get-ChildItem -Path "$path\Device Configurations" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfigurationAssignment.ps1
@@ -37,7 +37,7 @@ function Invoke-IntuneRestoreDeviceConfigurationAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceConfigurationAssignment.ps1
@@ -33,9 +33,13 @@ function Invoke-IntuneRestoreDeviceConfigurationAssignment {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all policies with assignments
     $deviceConfigurations = Get-ChildItem -Path "$Path\Device Configurations\Assignments" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceHealthScript.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneRestoreDeviceHealthScript {
     )
 
     #Connect to MS-Graph if required
-    if($null -eq (Get-MgContext)){
-        Connect-MgGraph -Scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all device health scripts
     $deviceHealthScripts = Get-ChildItem -Path "$Path\Device Health Scripts" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceHealthScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceHealthScript.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneRestoreDeviceHealthScript {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
@@ -29,7 +29,7 @@ function Invoke-IntuneRestoreDeviceManagementIntent {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementIntent.ps1
@@ -25,9 +25,13 @@ function Invoke-IntuneRestoreDeviceManagementIntent {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all device management intents
     $deviceManagementIntents = Get-ChildItem -Path "$Path\Device Management Intents" -Recurse -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
@@ -27,9 +27,13 @@ function Invoke-IntuneRestoreDeviceManagementScript {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all device management scripts
     $deviceManagementScripts = Get-ChildItem -Path "$Path\Device Management Scripts" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScript.ps1
@@ -31,7 +31,7 @@ function Invoke-IntuneRestoreDeviceManagementScript {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScriptAssignment.ps1
@@ -34,8 +34,13 @@ function Invoke-IntuneRestoreDeviceManagementScriptAssignment {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
     }
 
     # Get all policies with assignments

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScriptAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreDeviceManagementScriptAssignment.ps1
@@ -38,10 +38,9 @@ function Invoke-IntuneRestoreDeviceManagementScriptAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
-    }
 
     # Get all policies with assignments
     $deviceManagementScripts = Get-ChildItem -Path "$Path\Device Management Scripts\Assignments" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfiguration.ps1
@@ -24,9 +24,13 @@ function Invoke-IntuneRestoreGroupPolicyConfiguration {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Get all Group Policy Configurations
     $groupPolicyConfigurations = Get-ChildItem -Path "$Path\Administrative Templates" -File -ErrorAction SilentlyContinue

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfiguration.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfiguration.ps1
@@ -28,7 +28,7 @@ function Invoke-IntuneRestoreGroupPolicyConfiguration {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfigurationAssignment.ps1
@@ -37,7 +37,7 @@ function Invoke-IntuneRestoreGroupPolicyConfigurationAssignment {
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes
 

--- a/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfigurationAssignment.ps1
+++ b/IntuneBackupAndRestore/Public/Invoke-IntuneRestoreGroupPolicyConfigurationAssignment.ps1
@@ -33,9 +33,13 @@ function Invoke-IntuneRestoreGroupPolicyConfigurationAssignment {
     )
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }
+    $requiredScopes = @(
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes
 
     # Create the base requestBody
     $requestBody = @{

--- a/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
@@ -32,25 +32,15 @@ function Start-IntuneBackup() {
     }
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "EntitlementManagement.ReadWrite.All, DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementScripts.ReadWrite.All" 
-    }else{
-        Write-Host "MS-Graph already connected, checking scopes"
-        $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
-        $IncorrectScopes = $false
-        if ($scopes -notcontains "DeviceManagementApps.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementConfiguration.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementServiceConfig.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementManagedDevices.ReadWrite.All") {$IncorrectScopes = $true}
-		if ($scopes -notcontains "DeviceManagementScripts.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($IncorrectScopes) {
-            Write-Host "Incorrect scopes, please sign in again"
-            connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementScripts.ReadWrite.All"
-        }else{
-            Write-Host "MS-Graph scopes are correct"
-        }
-		Write-Host ""
-    }
+    $requiredScopes = @(
+		"EntitlementManagement.ReadWrite.All"
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes -CheckScopes
 
     Invoke-IntuneBackupAutopilotDeploymentProfile -Path $Path
     Invoke-IntuneBackupAutopilotDeploymentProfileAssignment -Path $Path

--- a/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneBackup.ps1
@@ -15,7 +15,7 @@ function Start-IntuneBackup() {
     .NOTES
     Requires the MSGraph SDK PowerShell Module
 
-    Connect to MSGraph first, using the 'Connect-MgGraph' cmdlet and the scopes: 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All'.
+    Connect to MSGraph first, using the 'Connect-MgGraph' cmdlet and the scopes: 'DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementScripts.ReadWrite.All'.
     #>
 
     [CmdletBinding()]
@@ -33,11 +33,9 @@ function Start-IntuneBackup() {
 
     #Connect to MS-Graph if required
     $requiredScopes = @(
-		"EntitlementManagement.ReadWrite.All"
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
         "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes -CheckScopes

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreAssignments.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreAssignments.ps1
@@ -37,24 +37,14 @@ function Start-IntuneRestoreAssignments() {
     }
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "EntitlementManagement.ReadWrite.All, DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }else{
-        Write-Host "MS-Graph already connected, checking scopes"
-        $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
-        $IncorrectScopes = $false
-        if ($scopes -notcontains "DeviceManagementApps.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementConfiguration.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementServiceConfig.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementManagedDevices.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($IncorrectScopes) {
-            Write-Host "Incorrect scopes, please sign in again"
-            connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
-        }else{
-            Write-Host "MS-Graph scopes are correct"     
-        }
-  
-    }
+    $requiredScopes = @(
+		"EntitlementManagement.ReadWrite.All"
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes -CheckScopes
 
     Invoke-IntuneRestoreAutopilotDeploymentProfileAssignment -Path $path -RestoreById $restoreById
     Invoke-IntuneRestoreConfigurationPolicyAssignment -Path $path -RestoreById $restoreById

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreAssignments.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreAssignments.ps1
@@ -38,11 +38,10 @@ function Start-IntuneRestoreAssignments() {
 
     #Connect to MS-Graph if required
     $requiredScopes = @(
-		"EntitlementManagement.ReadWrite.All"
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes -CheckScopes
 

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
@@ -32,24 +32,14 @@ function Start-IntuneRestoreConfig() {
     }
 
     #Connect to MS-Graph if required
-    if ($null -eq (Get-MgContext)) {
-        connect-mggraph -scopes "EntitlementManagement.ReadWrite.All, DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All" 
-    }else{
-        Write-Host "MS-Graph already connected, checking scopes"
-        $scopes = Get-MgContext | Select-Object -ExpandProperty Scopes
-        $IncorrectScopes = $false
-        if ($scopes -notcontains "DeviceManagementApps.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementConfiguration.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementServiceConfig.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($scopes -notcontains "DeviceManagementManagedDevices.ReadWrite.All") {$IncorrectScopes = $true}
-        if ($IncorrectScopes) {
-            Write-Host "Incorrect scopes, please sign in again"
-            connect-mggraph -scopes "DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.ReadWrite.All"
-        }else{
-            Write-Host "MS-Graph scopes are correct"     
-        }
-  
-    }
+    $requiredScopes = @(
+		"EntitlementManagement.ReadWrite.All"
+        "DeviceManagementApps.ReadWrite.All"
+        "DeviceManagementConfiguration.ReadWrite.All"
+        "DeviceManagementServiceConfig.ReadWrite.All"
+        "DeviceManagementManagedDevices.ReadWrite.All"
+    )
+    Test-GraphConnection -RequiredScopes $requiredScopes -CheckScopes
 
     Invoke-IntuneRestoreAutopilotDeploymentProfile -Path $Path
     Invoke-IntuneRestoreConfigurationPolicy -Path $Path

--- a/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
+++ b/IntuneBackupAndRestore/Public/Start-IntuneRestoreConfig.ps1
@@ -33,11 +33,10 @@ function Start-IntuneRestoreConfig() {
 
     #Connect to MS-Graph if required
     $requiredScopes = @(
-		"EntitlementManagement.ReadWrite.All"
         "DeviceManagementApps.ReadWrite.All"
         "DeviceManagementConfiguration.ReadWrite.All"
         "DeviceManagementServiceConfig.ReadWrite.All"
-        "DeviceManagementManagedDevices.ReadWrite.All"
+        "DeviceManagementScripts.ReadWrite.All"
     )
     Test-GraphConnection -RequiredScopes $requiredScopes -CheckScopes
 


### PR DESCRIPTION
The primary change added here is refactoring the MS Graph connection handling into a centralized function. The way it is structured should allow for different required scopes based on the process being performed.

Also noticed that a couple of the listed scopes may be incorrect:
- _EntitlementManagement_ was only listed in the **Start-** functions, nowhere else.
- There were no _ManagedDevice_ endpoints being called.
- _Scripts_ was not included, even though device health scripts are being processed

The current changes in this PR also fix that.

---

Currently marked as a draft because there's still a couple ideas to add here (open to feedback):

- The backup functions should really only require _Read.All_ scopes. I know it's easier to require _ReadWrite.All_ across the board to ensure parity across all functions, but it does present a potential security risk if the intended usage is simply to perform the backup process, not the restore process.
  - That is where allowing for the different scopes can come into play.

- Potential hot take: this module shouldn't be trying to automate/fix the connection to MS Graph at all; just checking that the required scopes are there, and exiting out if that is not the case.